### PR TITLE
feat(dash): Future-Features pipeline — capture ideas → roadmap

### DIFF
--- a/.claude/README.md
+++ b/.claude/README.md
@@ -17,9 +17,27 @@ Claude Code configuration that makes the dash self-managing.
 | `commands/dash-status.md` | `/dash-status` — read-only status |
 | `commands/evolve.md` | `/evolve` — run the self-evolution loop |
 | `commands/register-project.md` | `/register-project` — add/reconcile a project |
+| `commands/future-features.md` | `/future-features <idea>` — draft a full feature spec + place it on the right repo's roadmap |
+| `agents/feature-scout.md` | sub-agent that scans the session thread for latent feature ideas and proposes roadmap-ready specs (review/approval before backlog) |
+| `hooks/` | `SessionStart` + `Stop` hooks that make the Future-Features pipeline active in **every** session (see `hooks/README.md`) |
+| `settings.json` | registers the hooks above |
 
 MCP servers (github, memory, sequentialthinking, context7) are configured in the
 repo-root [`.mcp.json`](../.mcp.json).
+
+## The Future-Features pipeline
+
+Captures feature ideas before they're lost and routes them to the right repo's
+roadmap. The backlog is [`_data/roadmap.yml`](../_data/roadmap.yml) (source of
+truth; rendered at the dash **Roadmap** surface), targets come from
+[`_data/projects.yml`](../_data/projects.yml) (or `bamr87` for the monorepo).
+
+- **Manual:** `/future-features <idea>` → drafts a full spec → review/approval →
+  appends to `_data/roadmap.yml` (optionally opens a GitHub issue).
+- **Automatic:** a `SessionStart` hook keeps the workflow active; a throttled
+  `Stop` hook nudges the `feature-scout` sub-agent (once per session) when
+  feature-signal language appears. The scout **proposes**; a human approves;
+  nothing is backlogged without approval. Opt out with `FUTURE_FEATURES_AUTOSCOUT=0`.
 
 ## The self-evolution loop
 

--- a/.claude/agents/feature-scout.md
+++ b/.claude/agents/feature-scout.md
@@ -1,0 +1,52 @@
+---
+name: feature-scout
+description: Analyzes the current conversation/session thread for latent feature ideas, enhancement requests, pain points, and "it would be nice if…" moments, then authors complete, roadmap-ready feature specs for human review. Use proactively at the end of a substantive session, when the user asks to "scan for features" / "capture ideas", or when the Future-Features Stop hook requests it. Returns proposed specs; it does NOT write to the backlog itself.
+tools: Read, Grep, Glob, Bash
+model: inherit
+---
+
+You are **Feature Scout**. You mine a working session for feature ideas that
+would otherwise be lost, and turn them into precise, reviewable feature requests
+routed to the correct repository. You **propose**; a human approves; the main
+agent backlogs. You never write to `_data/roadmap.yml` yourself (you have no
+edit tools by design).
+
+## Inputs you can rely on
+- **The conversation so far** — the main agent passes it (or a summary) in your
+  prompt. Read it closely; that thread is your primary source.
+- [`_data/roadmap.yml`](_data/roadmap.yml) — the backlog, the schema every
+  proposal must match, and the existing `FF-NNNN` ids (don't collide; pick the
+  next free ids).
+- [`_data/projects.yml`](_data/projects.yml) — the catalog of target repos. The
+  root monorepo / dash is `bamr87` (`https://github.com/bamr87/bamr87`) and is
+  **not** in that file.
+
+## What counts as a feature idea
+Capture: explicit requests ("we should add…", "feature request:…"), wishes
+("it'd be nice if…", "I wish…"), recurring pain or friction, manual steps that
+beg for automation, `TODO`/`FIXME` asides, "in the future / eventually / down the
+line", and gaps you noticed while working. **Ignore:** routine bug fixes already
+handled, chit-chat, and anything already on the roadmap (check ids/titles first).
+
+## Method
+1. Re-read the thread; list candidate ideas, each with the quote/turn that
+   sparked it.
+2. Merge duplicates; drop anything already present in `_data/roadmap.yml`.
+3. For each survivor, resolve **one** target repo (registry match, or `bamr87`
+   for dash / monorepo / profile / CI ideas) and author a full spec conforming to
+   the roadmap schema: `title`, `status: proposed`, `priority`, `effort`,
+   `category`, `problem`, `proposal`, `acceptance[]`, optional `scope`/`risks`,
+   `source: scout`, `created` = today, next free `FF-NNNN` id, `issue_url: null`.
+4. Rank by value vs. effort. **Quality over quantity** — propose only ideas
+   genuinely worth tracking (typically 0–5). Returning **zero** is a valid,
+   correct outcome.
+
+## Output (return to the main agent — do NOT write files)
+- A short **summary table**: id · target repo · title · priority/effort · the
+  trigger quote.
+- For **each** proposal, the **exact YAML block** ready to append to
+  `_data/roadmap.yml`.
+- A one-line recommendation per item (backlog / needs-scoping / maybe-skip).
+- Close with: *"These are proposals only — awaiting human approval before
+  anything is added to `_data/roadmap.yml`."* If nothing qualifies, say so plainly
+  and stop.

--- a/.claude/commands/future-features.md
+++ b/.claude/commands/future-features.md
@@ -49,7 +49,9 @@ Show the **rendered spec** (human-readable) AND the **exact YAML block**. Then u
   `gh` CLI (repo convention — not MCP write tools, per
   `.github/docs/skills-agents-principles.md`):
   `gh issue create --repo <owner/repo> --title "<feature>" --body "<spec>" --label enhancement --label roadmap`
-  — then set the entry's `issue_url`.
+  — then set the entry's `issue_url`. If the repo has Issues disabled or the
+  create fails, skip it and keep `issue_url: null` — the local backlog is the
+  source of truth.
 - Confirm the new id and the file changed. Don't commit/push unless asked; the
   surrounding session/PR handles that.
 

--- a/.claude/commands/future-features.md
+++ b/.claude/commands/future-features.md
@@ -1,0 +1,54 @@
+---
+description: Turn an idea into a full feature spec and place it on the right repo's roadmap (_data/roadmap.yml)
+argument-hint: "[idea — optionally naming the target project]"
+---
+
+# Future Features — capture an idea as a roadmap-ready feature request
+
+Idea: $ARGUMENTS
+
+You are running the Future-Features capture flow. Turn the idea above into a
+**complete, reviewable feature request** and place it on the correct repo's
+roadmap. **Never** write to the backlog without explicit human approval.
+
+This is the manual, single-idea entry point. The `feature-scout` sub-agent does
+the same for ideas mined from a whole conversation — both share the schema and
+backlog below.
+
+## 1. Read the contracts
+- **Backlog + schema:** [`_data/roadmap.yml`](../../_data/roadmap.yml) — read the
+  header; every entry MUST conform, and ids are monotonic `FF-NNNN`.
+- **Target repos:** [`_data/projects.yml`](../../_data/projects.yml) — the catalog.
+
+## 2. Resolve the target repo (exactly one)
+- If the idea names a project/repo explicitly, use it.
+- Else match the idea's keywords / stack / domain against `_data/projects.yml`.
+- If the idea is about **this monorepo / the dash / the profile / registry / CI
+  itself**, target `bamr87` (`https://github.com/bamr87/bamr87`) — it is **not**
+  in the registry.
+- If two+ projects genuinely fit, **ask** with `AskUserQuestion` (offer the top
+  candidates). Don't guess on a coin-flip.
+
+## 3. Draft the full spec
+Author every required schema field: `title`, `status: proposed`, `priority`,
+`effort`, `category`, `problem`, `proposal`, `acceptance` (criteria list), plus
+`scope.in`/`scope.out` and `risks` where useful. Be concrete and specific to the
+chosen repo — read that project's README/code if it sharpens the scope. Assign
+the next free `FF-NNNN` id (scan existing ids), set `source: manual`, `created`
+to today's date, `issue_url: null`.
+
+## 4. Present for review
+Show the **rendered spec** (human-readable) AND the **exact YAML block**. Then use
+`AskUserQuestion` with options: **Approve**, **Approve + open GitHub issue**,
+**Edit**, **Reject**. Apply any edits and re-show before writing.
+
+## 5. On approval — backlog it
+- Append the YAML entry to `_data/roadmap.yml` (keep ids monotonic; keep the file
+  valid YAML).
+- If **Approve + open GitHub issue**: open an issue in the target repo via the
+  GitHub MCP (`mcp__github__issue_write`) — title = the feature, body = the spec,
+  labels `enhancement`, `roadmap` — then set the entry's `issue_url`.
+- Confirm the new id and the file changed. Don't commit/push unless asked; the
+  surrounding session/PR handles that.
+
+If **Reject**, write nothing.

--- a/.claude/commands/future-features.md
+++ b/.claude/commands/future-features.md
@@ -45,9 +45,11 @@ Show the **rendered spec** (human-readable) AND the **exact YAML block**. Then u
 ## 5. On approval — backlog it
 - Append the YAML entry to `_data/roadmap.yml` (keep ids monotonic; keep the file
   valid YAML).
-- If **Approve + open GitHub issue**: open an issue in the target repo via the
-  GitHub MCP (`mcp__github__issue_write`) — title = the feature, body = the spec,
-  labels `enhancement`, `roadmap` — then set the entry's `issue_url`.
+- If **Approve + open GitHub issue**: open an issue in the target repo with the
+  `gh` CLI (repo convention — not MCP write tools, per
+  `.github/docs/skills-agents-principles.md`):
+  `gh issue create --repo <owner/repo> --title "<feature>" --body "<spec>" --label enhancement --label roadmap`
+  — then set the entry's `issue_url`.
 - Confirm the new id and the file changed. Don't commit/push unless asked; the
   surrounding session/PR handles that.
 

--- a/.claude/hooks/README.md
+++ b/.claude/hooks/README.md
@@ -1,0 +1,53 @@
+# .claude/hooks/ — session hooks
+
+Shell/Python commands wired into Claude Code session lifecycle events via
+[`../settings.json`](../settings.json). They power the **Future-Features**
+pipeline so feature ideas are captured automatically in every session.
+
+## Hooks
+
+| Script | Event | What it does |
+|---|---|---|
+| `future_features_session_start.py` | `SessionStart` | Injects `additionalContext` that makes the Future-Features workflow active: reminds Claude it can capture ideas with `/future-features` and should run the `feature-scout` sub-agent at natural stopping points. |
+| `future_features_scout.py` | `Stop` | Scans the session transcript for feature-signal language in the **user's** messages; at most **once per session**, nudges Claude (`{"decision":"block","reason":…}`) to run the `feature-scout` sub-agent before stopping. |
+
+## Design notes
+
+- **Fail-open.** Any error or missing data → `exit 0` with no output. A
+  misbehaving hook must never block a session.
+- **Throttled.** The Stop hook writes a per-session marker under the system temp
+  dir (`$TMPDIR/claude-future-features/<hash>.nudged`) and fires only once per
+  session. It also respects `stop_hook_active` to avoid continuation loops.
+- **Targeted, not noisy.** It only fires when feature-signal phrases ("it'd be
+  nice if…", "we should add", "in the future", "roadmap", "enhancement", …)
+  appear, after at least two user turns, and never on its own injected context
+  (self-markers `future-features` / `feature-scout` are excluded from the scan).
+- **No silent writes.** The hooks only *prompt*; the `feature-scout` sub-agent
+  only *proposes*. Entries land in `_data/roadmap.yml` only after a human
+  approves.
+
+## Opt out
+
+Set `FUTURE_FEATURES_AUTOSCOUT=0` (`off`/`false`/`no`) in the environment to
+disable the automatic scout nudge. SessionStart still injects the capability
+note, minus the auto-scout instruction.
+
+## Test
+
+```bash
+# SessionStart emits valid context JSON
+echo '{"session_id":"s1","source":"startup"}' \
+  | python3 .claude/hooks/future_features_session_start.py | jq .
+
+# Stop fires on a transcript that contains feature-signal language
+printf '%s\n' \
+  '{"type":"user","message":{"role":"user","content":[{"type":"text","text":"a"}]}}' \
+  '{"type":"user","message":{"role":"user","content":[{"type":"text","text":"it would be nice if we added PDF export"}]}}' \
+  > /tmp/t.jsonl
+echo '{"session_id":"x","transcript_path":"/tmp/t.jsonl","stop_hook_active":false}' \
+  | python3 .claude/hooks/future_features_scout.py | jq .
+```
+
+See also: [`../commands/future-features.md`](../commands/future-features.md),
+[`../agents/feature-scout.md`](../agents/feature-scout.md), and the backlog
+[`../../_data/roadmap.yml`](../../_data/roadmap.yml).

--- a/.claude/hooks/future_features_scout.py
+++ b/.claude/hooks/future_features_scout.py
@@ -1,0 +1,143 @@
+#!/usr/bin/env python3
+"""Stop hook for the Future-Features pipeline.
+
+When a session is winding down and feature-signal language has appeared in the
+USER's messages, nudge the main agent — at most ONCE per session — to run the
+`feature-scout` sub-agent before stopping, so feature ideas are captured for
+review instead of lost.
+
+Contract:
+  stdin  : JSON with `transcript_path`, `session_id`, `stop_hook_active`, ...
+  stdout : on a nudge, JSON `{"decision": "block", "reason": "..."}` — the Stop
+           hook continuation that asks Claude to keep going and run the scout;
+           otherwise nothing (the session stops normally).
+Fail-open: any error / missing data -> exit 0 silently.
+Opt out  : FUTURE_FEATURES_AUTOSCOUT in {0,off,false,no} disables it.
+Throttle : one nudge per session (marker file under the system temp dir).
+"""
+import hashlib
+import json
+import os
+import re
+import sys
+import tempfile
+
+SIGNALS = [
+    r"it'?d be nice", r"it would be nice", r"would be nice", r"nice to have",
+    r"feature request", r"feature idea", r"new feature", r"future feature",
+    r"we should add", r"should support", r"could add", r"ought to support",
+    r"would be (?:great|cool|handy|useful)", r"\bi wish\b", r"\bwish ?list\b",
+    r"down the (?:road|line)", r"in the future", r"\beventually\b",
+    r"stretch goal", r"\bbacklog\b", r"\broadmap\b", r"enhancement",
+    r"would love (?:to|a|an|if|having)", r"what if we", r"automate this",
+]
+SIGNAL_RE = re.compile("|".join(SIGNALS), re.IGNORECASE)
+MIN_USER_TURNS = 2
+
+# Texts containing these markers are our own injected pipeline context — skip
+# them so the scanner never self-triggers.
+SELF_MARKERS = ("future-features", "feature-scout")
+
+
+def read_stdin_json() -> dict:
+    try:
+        return json.loads(sys.stdin.read() or "{}")
+    except Exception:
+        return {}
+
+
+def user_texts(transcript_path: str) -> list:
+    """Return the text of user-authored messages from the JSONL transcript.
+
+    Only `text` blocks of user-role messages are collected — tool results and
+    assistant output are deliberately excluded.
+    """
+    texts = []
+    try:
+        with open(transcript_path, "r", encoding="utf-8") as fh:
+            for line in fh:
+                line = line.strip()
+                if not line:
+                    continue
+                try:
+                    ev = json.loads(line)
+                except Exception:
+                    continue
+                if ev.get("type") != "user":
+                    continue
+                content = (ev.get("message") or {}).get("content")
+                if isinstance(content, str):
+                    texts.append(content)
+                elif isinstance(content, list):
+                    for block in content:
+                        if isinstance(block, dict) and block.get("type") == "text":
+                            texts.append(block.get("text", ""))
+                        elif isinstance(block, str):
+                            texts.append(block)
+    except Exception:
+        return []
+    return texts
+
+
+def main() -> None:
+    autoscout = os.environ.get("FUTURE_FEATURES_AUTOSCOUT", "1").strip().lower()
+    if autoscout in ("0", "off", "false", "no"):
+        sys.exit(0)
+
+    data = read_stdin_json()
+    if data.get("stop_hook_active"):  # already inside a stop-hook continuation
+        sys.exit(0)
+
+    session_id = str(data.get("session_id") or "unknown")
+    transcript = data.get("transcript_path") or ""
+    if not transcript or not os.path.exists(transcript):
+        sys.exit(0)
+
+    # Throttle: one nudge per session.
+    key = hashlib.sha1(session_id.encode("utf-8")).hexdigest()[:16]
+    state_dir = os.path.join(tempfile.gettempdir(), "claude-future-features")
+    marker = os.path.join(state_dir, key + ".nudged")
+    if os.path.exists(marker):
+        sys.exit(0)
+
+    texts = user_texts(transcript)
+    if len([t for t in texts if t.strip()]) < MIN_USER_TURNS:
+        sys.exit(0)  # trivial session — nothing worth scouting
+
+    scan = "\n".join(
+        t for t in texts if not any(m in t.lower() for m in SELF_MARKERS)
+    )
+    hits = sorted({m.group(0).lower() for m in SIGNAL_RE.finditer(scan)})
+    if not hits:
+        sys.exit(0)  # no marker written — a later turn can still trigger
+
+    # Record the nudge so it fires at most once per session.
+    try:
+        os.makedirs(state_dir, exist_ok=True)
+        with open(marker, "w", encoding="utf-8") as fh:
+            fh.write(session_id)
+    except Exception:
+        pass
+
+    reason = (
+        "Future-Features: this session surfaced possible feature ideas (signals: "
+        + ", ".join(hits[:8])
+        + '). Before you stop, invoke the `feature-scout` sub-agent (Task/Agent tool, '
+        'subagent_type "feature-scout") to analyze the whole thread and author '
+        "roadmap-ready specs. Present each proposed spec for the user's "
+        "review/approval; append only approved entries to `_data/roadmap.yml` "
+        "(route each to the right repo via `_data/projects.yml`, or `bamr87` for the "
+        "monorepo). If, on reflection, nothing rises to a genuine feature request, say "
+        "so in one line and stop. (Fires at most once per session; disable with "
+        "FUTURE_FEATURES_AUTOSCOUT=0.)"
+    )
+    print(json.dumps({"decision": "block", "reason": reason}))
+    sys.exit(0)
+
+
+if __name__ == "__main__":
+    try:
+        main()
+    except Exception:
+        # Fail open: a misbehaving hook must never block a session.
+        sys.exit(0)

--- a/.claude/hooks/future_features_session_start.py
+++ b/.claude/hooks/future_features_session_start.py
@@ -14,9 +14,9 @@ import json
 import os
 import sys
 
-# Sentinel embedded in injected text so the Stop-hook scanner can exclude its
-# own context and avoid self-triggering on words like "roadmap"/"backlog".
-SENTINEL = "future-features"
+# The injected text below intentionally contains the self-markers
+# ("future-features" / "feature-scout") that the Stop hook's SELF_MARKERS filter
+# excludes from its scan, so this context never self-triggers the scout nudge.
 
 
 def main() -> None:

--- a/.claude/hooks/future_features_session_start.py
+++ b/.claude/hooks/future_features_session_start.py
@@ -1,0 +1,64 @@
+#!/usr/bin/env python3
+"""SessionStart hook for the Future-Features pipeline.
+
+Injects a short standing instruction into every Claude Code session so the
+Future-Features workflow is active: Claude knows it can capture ideas with
+`/future-features` and should run the `feature-scout` sub-agent at natural
+stopping points to harvest feature ideas from the thread for human review.
+
+Contract: prints SessionStart `additionalContext` JSON to stdout.
+Fail-open: any error -> exit 0 with no output (never break a session).
+Opt out : set FUTURE_FEATURES_AUTOSCOUT=0 (off/false/no) to silence the scout nudge.
+"""
+import json
+import os
+import sys
+
+# Sentinel embedded in injected text so the Stop-hook scanner can exclude its
+# own context and avoid self-triggering on words like "roadmap"/"backlog".
+SENTINEL = "future-features"
+
+
+def main() -> None:
+    try:
+        sys.stdin.read()  # consume stdin; not needed here
+    except Exception:
+        pass
+
+    autoscout = os.environ.get("FUTURE_FEATURES_AUTOSCOUT", "1").strip().lower()
+    scout_on = autoscout not in ("0", "off", "false", "no")
+
+    context = (
+        "Future-Features pipeline is active in this repo.\n"
+        "- Capture a single idea anytime with `/future-features <idea>` — it drafts a "
+        "full spec and, on your approval, adds it to `_data/roadmap.yml` for the right repo.\n"
+        "- The backlog + schema live in `_data/roadmap.yml`; target repos come from "
+        "`_data/projects.yml` (use `bamr87` for the monorepo/dash itself).\n"
+    )
+    if scout_on:
+        context += (
+            "- When this session has surfaced feature-worthy ideas (wishes, "
+            '"it\'d be nice if…", repeated friction, automation opportunities, TODO '
+            'asides), proactively invoke the `feature-scout` sub-agent (Task/Agent tool, '
+            'subagent_type "feature-scout") to analyze the thread and author '
+            "roadmap-ready specs. Present each for review; write only approved entries "
+            "to `_data/roadmap.yml`. Never backlog without explicit human approval.\n"
+            "- A Stop hook may also remind you once per session when such language appears."
+        )
+
+    out = {
+        "hookSpecificOutput": {
+            "hookEventName": "SessionStart",
+            "additionalContext": context,
+        }
+    }
+    print(json.dumps(out))
+    sys.exit(0)
+
+
+if __name__ == "__main__":
+    try:
+        main()
+    except Exception:
+        # Fail open: a misbehaving hook must never block a session.
+        sys.exit(0)

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,25 @@
+{
+  "$schema": "https://json.schemastore.org/claude-code-settings.json",
+  "hooks": {
+    "SessionStart": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "python3 \"$CLAUDE_PROJECT_DIR/.claude/hooks/future_features_session_start.py\""
+          }
+        ]
+      }
+    ],
+    "Stop": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "python3 \"$CLAUDE_PROJECT_DIR/.claude/hooks/future_features_scout.py\""
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/_data/navigation/dash.yml
+++ b/_data/navigation/dash.yml
@@ -8,6 +8,8 @@
       url: /projects/
     - title: 🩺 Monitor
       url: /monitor/
+    - title: 🗺️ Roadmap
+      url: /roadmap/
     - title: 🧰 Toolbox
       url: /toolbox/
     - title: 📄 Resume

--- a/_data/navigation/main.yml
+++ b/_data/navigation/main.yml
@@ -11,6 +11,8 @@
       url: /dashboard/
     - title: Monitor
       url: /monitor/
+    - title: Roadmap
+      url: /roadmap/
     - title: Toolbox
       url: /toolbox/
     - title: Resume

--- a/_data/roadmap.yml
+++ b/_data/roadmap.yml
@@ -80,3 +80,41 @@
   source: manual
   created: 2026-06-21
   issue_url: null
+
+- id: FF-0002
+  title: "`tools/dash roadmap` CLI subcommand — list and add roadmap items from the terminal"
+  project: bamr87
+  repo_url: https://github.com/bamr87/bamr87
+  status: proposed
+  priority: P2
+  effort: S
+  category: feature
+  problem: >-
+    Capturing or reviewing roadmap items today means hand-editing
+    _data/roadmap.yml or running a full Claude session. There is no quick
+    terminal way to see what's on the roadmap or jot a new item — friction for
+    fast capture and for scripting.
+  proposal: >-
+    Add a `roadmap` subcommand to tools/dash following the existing cmd_* + case
+    dispatch: `tools/dash roadmap [list|add|next-id]`. `list` prints items
+    (filterable by --status/--project); `add` appends a schema-valid entry with
+    the next FF id (status proposed, source manual); reuse python3 + pyyaml.
+  acceptance:
+    - "`tools/dash roadmap list` prints items grouped by status; --status/--project filter."
+    - "`tools/dash roadmap add` appends a valid entry with the next FF-NNNN id, status proposed, source manual, created=today."
+    - "`tools/dash roadmap next-id` prints the next free id."
+    - "Output stays valid YAML, passes the roadmap schema check, and shows in `tools/dash help`."
+    - "Resolves --project to a registry name or `bamr87`; rejects unknown projects helpfully."
+  scope:
+    in:
+      - tools/dash roadmap subcommand (list/add/next-id) + schema validation
+    out:
+      - editing/deleting existing items
+      - GitHub issue sync (stays in /future-features)
+      - a TUI
+  risks:
+    - pyyaml round-trip may reorder keys / drop header comments — append text, don't re-dump.
+    - Keep id allocation consistent with the slash command (single next-id source).
+  source: manual
+  created: 2026-06-21
+  issue_url: null

--- a/_data/roadmap.yml
+++ b/_data/roadmap.yml
@@ -1,0 +1,82 @@
+# =============================================================================
+# _data/roadmap.yml  —  THE FEATURE BACKLOG / ROADMAP (single source of truth)
+# =============================================================================
+# Every feature request captured by the Future-Features pipeline lands here:
+#   - `/future-features <idea>`  (manual entry point — one idea)
+#   - the `feature-scout` sub-agent (automatic — scans the session thread)
+#
+# This file is committed and reviewable. The dash Roadmap surface
+# (pages/_dash/roadmap.md) renders it, and entries optionally mirror to a
+# GitHub issue in the target repo once approved.
+#
+# WORKFLOW
+#   proposed  → drafted by the command/scout, awaiting human review/approval
+#   approved  → accepted into the backlog (next up for scoping)
+#   backlog   → planned, not yet started
+#   in-progress
+#   shipped   → delivered
+#   declined  → reviewed and rejected (kept for the record; set `reason`)
+#
+# Nothing is written here without human approval. The sub-agent only *proposes*;
+# a human approves before the entry is committed.
+#
+# -----------------------------------------------------------------------------
+# Schema (per entry):
+#   id          required  stable id, `FF-NNNN` (monotonic; never reuse)
+#   title       required  short imperative summary
+#   project     required  target project `name` from _data/projects.yml,
+#                         or `bamr87` for the root dash / this monorepo itself
+#   repo_url    required  GitHub repo the feature targets
+#   status      required  proposed | approved | backlog | in-progress | shipped | declined
+#   priority    required  P0 (now) | P1 (soon) | P2 (later) | P3 (someday)
+#   effort      required  S | M | L | XL  (rough t-shirt size)
+#   category    required  feature | enhancement | infra | docs | research | fix
+#   problem     required  the user/maintainer pain, in one or two sentences
+#   proposal    required  the proposed solution / what to build
+#   acceptance  required  list of acceptance criteria (what "done" looks like)
+#   scope       optional  { in: [...], out: [...] }  explicit in/out of scope
+#   risks       optional  list of risks / open questions
+#   source      required  where it came from: `manual`, `scout`, or `session:<id>`
+#   created     required  ISO date (YYYY-MM-DD)
+#   issue_url   optional  GitHub issue URL once mirrored (null until then)
+#   reason      optional  rationale when status is `declined`
+# =============================================================================
+
+- id: FF-0001
+  title: Future-Features pipeline — capture, spec, and backlog feature ideas
+  project: bamr87
+  repo_url: https://github.com/bamr87/bamr87
+  status: in-progress
+  priority: P1
+  effort: M
+  category: infra
+  problem: >-
+    Good feature ideas surface mid-conversation while working in a session and
+    are lost when the session ends. There is no consistent way to turn a passing
+    idea into a well-formed, reviewable feature request on the right repo's
+    roadmap.
+  proposal: >-
+    A Future-Features pipeline: a `/future-features` slash command that turns an
+    idea into a full spec and routes it to the correct repo's roadmap, plus a
+    `feature-scout` sub-agent wired to a session hook that scans the thread for
+    latent feature ideas and presents complete specs for human review before
+    anything is backlogged in this file.
+  acceptance:
+    - "`/future-features <idea>` drafts a full spec and, on approval, appends an entry here."
+    - "The target repo is resolved from _data/projects.yml (or `bamr87` for the root)."
+    - "A `feature-scout` sub-agent analyzes the conversation and proposes specs."
+    - "A SessionStart hook makes the workflow active in every Claude Code session."
+    - "A Stop hook nudges the scout when feature-signal language appears (throttled, opt-out)."
+    - "Nothing is committed to this file without explicit human approval."
+  scope:
+    in:
+      - slash command, sub-agent, hooks, this backlog file, dash Roadmap surface
+    out:
+      - automatic GitHub issue creation without approval
+      - cross-repo epics / dependency tracking
+  risks:
+    - Hook noise — mitigated by once-per-session throttling and an opt-out env var.
+    - Mis-routing an idea to the wrong repo — mitigated by a confirmation step.
+  source: manual
+  created: 2026-06-21
+  issue_url: null

--- a/docs/DASH.md
+++ b/docs/DASH.md
@@ -38,6 +38,7 @@ follow.
 | Drift gates | Hard CI checks | `tools/check-drift.sh` + `.github/workflows/drift-check.yml` |
 | Auto-fix bots | Scheduled PRs | `update-submodules.yml`, `refresh-dash.yml`, `dependabot.yml` |
 | AI layer | Skills, commands, MCP | `.claude/`, `.mcp.json` |
+| Future-Features | Capture feature ideas → roadmap | `_data/roadmap.yml`, `/future-features`, `feature-scout` agent + session hooks (`.claude/`) |
 | Self-evolution | Weekly AI pass | `.github/workflows/unified-evolution.yml` (Claude Code) |
 
 ## The dash CLI

--- a/pages/_dash/dashboard.md
+++ b/pages/_dash/dashboard.md
@@ -16,6 +16,7 @@ an AI orchestration layer.
 <div class="row text-center my-4">
   <div class="col-md-3 col-6 mb-3"><a class="btn btn-outline-primary w-100" href="{{ '/projects/' | relative_url }}">🎨 Portfolio</a></div>
   <div class="col-md-3 col-6 mb-3"><a class="btn btn-outline-primary w-100" href="{{ '/monitor/' | relative_url }}">🩺 Monitor</a></div>
+  <div class="col-md-3 col-6 mb-3"><a class="btn btn-outline-primary w-100" href="{{ '/roadmap/' | relative_url }}">🗺️ Roadmap</a></div>
   <div class="col-md-3 col-6 mb-3"><a class="btn btn-outline-primary w-100" href="{{ '/toolbox/' | relative_url }}">🧰 Toolbox</a></div>
   <div class="col-md-3 col-6 mb-3"><a class="btn btn-outline-primary w-100" href="{{ '/resume/' | relative_url }}">📄 Resume</a></div>
 </div>

--- a/pages/_dash/roadmap.md
+++ b/pages/_dash/roadmap.md
@@ -46,15 +46,15 @@ or let the <code>feature-scout</code> sub-agent harvest them from a session.
   <tbody>
   {% for it in items %}
     <tr>
-      <td><code>{{ it.id }}</code></td>
+      <td><code>{{ it.id | escape }}</code></td>
       <td>
-        {% if it.issue_url %}<a href="{{ it.issue_url }}">{{ it.title }}</a>{% else %}{{ it.title }}{% endif %}
-        <br><small class="text-muted">{{ it.problem | strip_newlines | truncate: 130 }}</small>
+        {% if it.issue_url %}<a href="{{ it.issue_url | escape }}">{{ it.title | escape }}</a>{% else %}{{ it.title | escape }}{% endif %}
+        <br><small class="text-muted">{{ it.problem | strip_newlines | truncate: 130 | escape }}</small>
       </td>
-      <td><a href="{{ it.repo_url }}">{{ it.project }}</a></td>
-      <td><span class="badge bg-secondary">{{ it.priority }}</span></td>
-      <td>{{ it.effort }}</td>
-      <td>{{ it.category }}</td>
+      <td><a href="{{ it.repo_url | escape }}">{{ it.project | escape }}</a></td>
+      <td><span class="badge bg-secondary">{{ it.priority | escape }}</span></td>
+      <td>{{ it.effort | escape }}</td>
+      <td>{{ it.category | escape }}</td>
     </tr>
   {% endfor %}
   </tbody>

--- a/pages/_dash/roadmap.md
+++ b/pages/_dash/roadmap.md
@@ -1,0 +1,69 @@
+---
+layout: default
+title: Roadmap
+description: Feature backlog across every tracked repo — captured by the Future-Features pipeline.
+permalink: /roadmap/
+sidebar:
+  nav: dash
+---
+
+# 🗺️ Roadmap
+
+The feature backlog, generated from <code>_data/roadmap.yml</code> — the single
+source of truth captured by the **Future-Features** pipeline
+(`/future-features` + the `feature-scout` sub-agent). Each item is routed to a
+target repo from [`_data/projects.yml`]({{ '/toolbox/' | relative_url }}), or to
+`bamr87` for the monorepo itself.
+
+{% assign roadmap = site.data.roadmap %}
+{% if roadmap == nil or roadmap.size == 0 %}
+<div class="alert alert-info">
+No roadmap items yet. Capture one with <code>/future-features &lt;idea&gt;</code>,
+or let the <code>feature-scout</code> sub-agent harvest them from a session.
+</div>
+{% else %}
+
+<div class="row text-center my-4">
+  <div class="col-md-3 col-6 mb-3"><div class="card"><div class="card-body"><h2>{{ roadmap.size }}</h2><div class="text-muted">Total</div></div></div></div>
+  <div class="col-md-3 col-6 mb-3"><div class="card"><div class="card-body"><h2>{{ roadmap | where: "status", "proposed" | size }}</h2><div class="text-muted">Proposed</div></div></div></div>
+  <div class="col-md-3 col-6 mb-3"><div class="card"><div class="card-body"><h2>{{ roadmap | where: "status", "in-progress" | size }}</h2><div class="text-muted">In progress</div></div></div></div>
+  <div class="col-md-3 col-6 mb-3"><div class="card"><div class="card-body"><h2>{{ roadmap | where: "status", "shipped" | size }}</h2><div class="text-muted">Shipped</div></div></div></div>
+</div>
+
+{% assign statuses = "in-progress,approved,backlog,proposed,shipped,declined" | split: "," %}
+{% assign labels = "🚧 In progress,✅ Approved,🗂️ Backlog,💡 Proposed,🚀 Shipped,🚫 Declined" | split: "," %}
+
+{% for st in statuses %}
+{% assign items = roadmap | where: "status", st %}
+{% if items.size > 0 %}
+## {{ labels[forloop.index0] }} <small class="text-muted">({{ items.size }})</small>
+
+<div class="table-responsive">
+<table class="table table-sm align-middle">
+  <thead>
+    <tr><th>ID</th><th>Feature</th><th>Repo</th><th>Priority</th><th>Effort</th><th>Category</th></tr>
+  </thead>
+  <tbody>
+  {% for it in items %}
+    <tr>
+      <td><code>{{ it.id }}</code></td>
+      <td>
+        {% if it.issue_url %}<a href="{{ it.issue_url }}">{{ it.title }}</a>{% else %}{{ it.title }}{% endif %}
+        <br><small class="text-muted">{{ it.problem | strip_newlines | truncate: 130 }}</small>
+      </td>
+      <td><a href="{{ it.repo_url }}">{{ it.project }}</a></td>
+      <td><span class="badge bg-secondary">{{ it.priority }}</span></td>
+      <td>{{ it.effort }}</td>
+      <td>{{ it.category }}</td>
+    </tr>
+  {% endfor %}
+  </tbody>
+</table>
+</div>
+{% endif %}
+{% endfor %}
+
+<p class="small text-muted">Source: <code>_data/roadmap.yml</code>. Add items with
+<code>/future-features</code> or let the <code>feature-scout</code> sub-agent
+harvest them from a session — nothing is backlogged without human approval.</p>
+{% endif %}


### PR DESCRIPTION
## What & why

Good feature ideas surface mid-session and get lost when the session ends. This adds a **Future-Features pipeline** that turns a passing idea into a well-formed, reviewable feature request on the right repo's roadmap — manually on demand, and automatically in every session. **Nothing is backlogged without explicit human approval.**

## How it works

```
/future-features <idea> ─┐                          ┌─ review/approve ─→ _data/roadmap.yml
                         ├─→ full spec, routed repo ─┤                    (+ optional GitHub issue)
feature-scout sub-agent ─┘  (proposes only)          └─ reject ─→ nothing written
   ▲
   └─ SessionStart hook keeps it active · Stop hook nudges once/session on feature-signal language
```

## Changes

| Piece | File | Role |
|---|---|---|
| Slash command | `.claude/commands/future-features.md` | `/future-features <idea>` → drafts a full spec, resolves the target repo from `_data/projects.yml` (or `bamr87` for the monorepo), and on approval appends to `_data/roadmap.yml` (optionally opens a GitHub issue with `enhancement`,`roadmap` labels). |
| Sub-agent | `.claude/agents/feature-scout.md` | Scans the session thread for latent feature ideas and authors roadmap-ready specs **for review**. Propose-only — no edit tools by design; the main agent backlogs after approval. |
| Session hooks | `.claude/hooks/*.py` + `.claude/settings.json` | `SessionStart` injects the workflow context (active every session); throttled, fail-open `Stop` hook nudges the scout **once per session** when feature-signal language appears in user messages. |
| Backlog | `_data/roadmap.yml` | Single source of truth (documented schema). Seeded with `FF-0001` (this pipeline). |
| Dash surface | `pages/_dash/roadmap.md` + nav | New `/roadmap/` page grouping items by status, wired into dash + main nav and the Dashboard quick-links. |
| Docs | `.claude/README.md`, `.claude/hooks/README.md`, `docs/DASH.md` | README-First/Last. |

## Safety / good-citizen design

- **Fail-open hooks:** any error or missing data → `exit 0`, no output — a hook never blocks a session.
- **Throttled & targeted:** Stop hook fires at most once per session, only after ≥2 user turns, only on signal phrases, respects `stop_hook_active`, and excludes its own injected context (no self-trigger).
- **Opt out:** `FUTURE_FEATURES_AUTOSCOUT=0`.
- **Human-in-the-loop:** the scout proposes; a human approves; only then is `_data/roadmap.yml` written.

## Testing

- 7 hook scenarios verified: SessionStart context emission, opt-out, Stop trigger on signal language, once-per-session throttle, `stop_hook_active` guard, no-signal silence, and self-marker exclusion.
- `_data/roadmap.yml` / nav YAML, `settings.json`, and all new frontmatter validate; Roadmap page Liquid tags balanced.
- Drift gate: README freshness (b) and README presence (d) pass. The registry/submodule-branch parity lines are a pre-existing artifact of this remote environment (submodules checked out on the session branch instead of detached HEAD) — unrelated to this change and tolerated by CI's detached-HEAD checkout.

## Try it

```
/future-features add dark-mode toggle to the dash
```

Or just work normally — when a session surfaces "it'd be nice if…" ideas, the scout offers specs for the backlog before you stop.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013Ge8QEkCnc9zWdgdMStHZ4

---
_Generated by [Claude Code](https://claude.ai/code/session_013Ge8QEkCnc9zWdgdMStHZ4)_