### PR TITLE
fix(site): complete main-nav coverage — sitemap + 404 pages, unpublish internal orphans

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -239,3 +239,13 @@ exclude:
   - CONTRIBUTING.md
   - SUBMODULES.md
   - "*.code-workspace"
+  # Governance/template content that must never publish as pages. NOTE: the
+  # github-pages gem force-enables jekyll-optional-front-matter, so even .md
+  # files WITHOUT front matter render unless excluded (exclude is prefix-
+  # matched — root SCHEMA.md does not cover pages/SCHEMA.md).
+  - SCHEMA.md
+  - pages/SCHEMA.md
+  - templates/
+  - _reports/
+  - daily-analysis-workorder.md
+  - actions-review-workorder.md

--- a/_data/navigation/main.yml
+++ b/_data/navigation/main.yml
@@ -1,7 +1,11 @@
 # Main Navigation
-# Used by: _includes/navigation/navbar.html (zer0-mistakes theme)
+# Used by: _includes/navigation/navbar.html, navbar-mobile-quicklinks.html,
+#          unified-drawer.html (zer0-mistakes theme)
 # Schema: list of { title, icon (Bootstrap Icons bi-*), url, children[] }
-# Order: Dashboard (far left) → Projects → Services → About (far right).
+# Every rendered page must be reachable from here (directly or via its hub):
+# dash pages also appear in the per-page sidebar (_data/navigation/dash.yml) —
+# keep the two files' groupings aligned when adding a page.
+# Order: Dashboard (far left) → Finance → Projects → Blog → Services → About.
 
 - title: Dashboard
   icon: bi-speedometer2
@@ -11,18 +15,33 @@
       url: /dashboard/
     - title: Monitor
       url: /monitor/
+    - title: Fleet Triage
+      url: /triage/
     - title: Roadmap
       url: /roadmap/
     - title: Toolbox
       url: /toolbox/
+
+- title: Finance
+  icon: bi-cash-stack
+  url: /cockpit/
+  children:
+    - title: Cost Cockpit
+      url: /cockpit/
+    - title: AI Usage
+      url: /ai-usage/
     - title: AI Activity
       url: /ai-activity/
-    - title: Resume
-      url: /resume/
+    - title: Actions Usage
+      url: /actions/
 
 - title: Projects
   icon: bi-collection
   url: /projects/
+
+- title: Blog
+  icon: bi-journal-text
+  url: /blog/
 
 - title: Services
   icon: bi-gear-wide-connected
@@ -47,5 +66,9 @@
       url: /about/#technical-stack--specializations
     - title: Experience
       url: /experience/
+    - title: Resume
+      url: /resume/
+    - title: Docs
+      url: /docs/
     - title: Contact
       url: /contact/

--- a/pages/_pages/404.md
+++ b/pages/_pages/404.md
@@ -1,0 +1,18 @@
+---
+title: "Page not found"
+layout: default
+permalink: /404.html
+sitemap: false
+---
+
+# 404 — that page drifted out of orbit
+
+The page you asked for doesn't exist (or moved). The whole site is still one click away:
+
+- 🏠 [Home]({{ '/' | relative_url }}) — the front door
+- 📊 [Dashboard]({{ '/dashboard/' | relative_url }}) — the command center
+- 📥 [Fleet Triage]({{ '/triage/' | relative_url }}) — everything open across the fleet
+- 🎨 [Projects]({{ '/projects/' | relative_url }}) — the portfolio
+- 🗺️ [Sitemap]({{ '/sitemap/' | relative_url }}) — every page on this site
+
+Think this URL should exist? [Open an issue](https://github.com/bamr87/bamr87/issues/new) and it becomes tomorrow's triage item.

--- a/pages/_pages/sitemap.md
+++ b/pages/_pages/sitemap.md
@@ -1,0 +1,36 @@
+---
+title: "Sitemap"
+description: "Every page on this site, grouped the same way as the navigation."
+layout: default
+permalink: /sitemap/
+---
+
+# 🗺️ Sitemap
+
+Every page on this site, grouped as in the header navigation. The machine-readable version is [sitemap.xml]({{ '/sitemap.xml' | relative_url }}).
+
+{% assign nav = site.data.navigation.main %}
+{% for group in nav %}
+
+## {% if group.icon %}<i class="{{ group.icon }}"></i> {% endif %}[{{ group.title }}]({{ group.url | relative_url }})
+
+{% if group.children and group.children.size > 0 %}
+<ul>
+{% for child in group.children %}
+<li><a href="{{ child.url | relative_url }}">{{ child.title }}</a></li>
+{% endfor %}
+</ul>
+{% else %}
+<p><a href="{{ group.url | relative_url }}">{{ group.title }}</a></p>
+{% endif %}
+{% endfor %}
+
+## 📝 Blog posts
+
+<ul>
+{% for post in site.posts %}
+<li><a href="{{ post.url | relative_url }}">{{ post.title }}</a> <small class="text-muted">({{ post.date | date: "%Y-%m-%d" }})</small></li>
+{% endfor %}
+</ul>
+
+<p class="small text-muted">Home is always one click away via the site title in the header. Dash pages also carry the Command Center sidebar for lateral movement.</p>


### PR DESCRIPTION
## What

Full navigation audit of the live GitHub Pages site (bamr87.github.io/bamr87/), then fixes so **every page is reachable from the main navigation** and there's always a path around the site.

## Audit result (3-agent verification against the live sitemap.xml)

**Reachable & sound** ✅ — all 12 dash pages carry the Command Center sidebar (config defaults cover even the `article`-layout ones); posts are reachable via `/blog/`; home via the brand link on every layout; all 5 section anchors verified against live kramdown heading ids; zero dead links in either nav file.

**Gaps found & fixed here:**

| Gap | Fix |
| --- | --- |
| 6 pages absent from the header nav: `/cockpit/`, `/ai-usage/`, `/ai-activity/`\*, `/actions/`, `/docs/`, `/triage/`, plus `/blog/` (orphaning posts) | `main.yml` restructured: new **Finance** group mirroring the dash sidebar, **Fleet Triage** under Dashboard, top-level **Blog**, Resume + Docs under About — all 17 pages now directly linked (\*AI Activity moved from Dashboard to Finance) |
| **9 orphan internal pages published**: `/SCHEMA/`, `/pages/SCHEMA/`, `/templates/`, `/templates/SCHEMA/`, 3× schema kit files, agent-context + release templates (github-pages gem force-enables `jekyll-optional-front-matter`, so even no-front-matter `.md` renders) | `_config.yml` excludes: `SCHEMA.md`, `pages/SCHEMA.md`, `templates/` (+ workorder strays). No effect on `tools/fanout.sh` — it reads the working tree, not the built site |
| Footer "Sitemap" link (`repo_map: /sitemap/`) 404s | New **`/sitemap/`** page — human-readable directory generated from the nav data + posts; footer upgrades automatically |
| No 404 page — GitHub's unstyled dead-end | New **`/404.html`** with the site chrome and routes to Home / Dashboard / Triage / Projects / Sitemap |

## Theme follow-ups (zer0-mistakes repo — intentionally not bundled)

- `navbar-mobile-quicklinks.html` hard `limit: 5` drops the 6th group's chip at tablet widths (About — still reachable via the offcanvas menu)
- invalid `{% assign x = a and b %}` in `navbar.html`/`nav-tree.html` (works by accident)
- whitespace-control jams attributes (`aria-label="…"aria-current=…`) in navbar items
- breadcrumbs only render inside the Settings offcanvas despite `breadcrumbs: true`

Happy to open these as issues/PRs in `projects/zer0-mistakes` next.

🤖 Generated with [Claude Code](https://claude.com/claude-code)