### PR TITLE
fix(dash): theme-aware tables/badges + restore Actions chart

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -72,6 +72,10 @@ navigation:
 
 # Appearance -------------------------------------------------------------------
 theme_skin               : "air"   # air, aqua, dirt, neon, mint, plum, sunrise
+# Load assets/css/user-overrides.css (last, after main.css) on every page — the
+# theme-sanctioned hook for consumer CSS. Fixes Bootstrap contextual table/badge
+# classes that ignore the dark-mode toggle across the dash surfaces.
+user_overrides           : true
 theme_background:
   enabled: true
   gradient_opacity: 0.6

--- a/assets/css/user-overrides.css
+++ b/assets/css/user-overrides.css
@@ -1,0 +1,79 @@
+/* ==========================================================================
+   user-overrides.css — consumer overrides for the bamr87 dash
+   Loaded LAST (after main.css + tokens-inline) via `site.user_overrides: true`,
+   so these rules win over both the compiled theme and Bootstrap defaults.
+
+   Purpose: the dash pages (monitor, triage, actions, …) lean on Bootstrap's
+   contextual helpers — `.table-danger/.warning/.success/.light` rows and
+   `.badge.bg-light.text-dark`. Those ship FIXED LIGHT colours: on the theme's
+   dark surface they render as glaring near-white blocks with washed-out text.
+   Here we redefine them as translucent, semantic tints that composite over the
+   current `--bs-body-bg`, so a red row reads as pale-pink on light and deep-red
+   on dark — legible in both, driven by the same colour toggle as everything else.
+   ========================================================================== */
+
+/* ---------- Theme-aware contextual table rows ---------------------------- */
+/* Keep row TEXT at the body colour (Bootstrap forces near-black), and swap the
+   opaque variant background for a translucent semantic tint. Because the tint
+   carries alpha, the page background shows through and the row adapts per theme. */
+.table > :not(caption) > * > *,
+.table-danger,
+.table-warning,
+.table-success,
+.table-info,
+.table-primary,
+.table-secondary,
+.table-light {
+  --bs-table-color: var(--bs-body-color);
+  --bs-table-color-state: var(--bs-body-color);
+}
+
+.table-danger {
+  --bs-table-bg: rgba(var(--bs-danger-rgb), 0.13);
+  --bs-table-border-color: rgba(var(--bs-danger-rgb), 0.28);
+  --bs-table-hover-bg: rgba(var(--bs-danger-rgb), 0.22);
+  --bs-table-striped-bg: rgba(var(--bs-danger-rgb), 0.18);
+  --bs-table-active-bg: rgba(var(--bs-danger-rgb), 0.24);
+}
+.table-warning {
+  --bs-table-bg: rgba(var(--bs-warning-rgb), 0.15);
+  --bs-table-border-color: rgba(var(--bs-warning-rgb), 0.30);
+  --bs-table-hover-bg: rgba(var(--bs-warning-rgb), 0.24);
+  --bs-table-striped-bg: rgba(var(--bs-warning-rgb), 0.20);
+  --bs-table-active-bg: rgba(var(--bs-warning-rgb), 0.26);
+}
+.table-success {
+  --bs-table-bg: rgba(var(--bs-success-rgb), 0.13);
+  --bs-table-border-color: rgba(var(--bs-success-rgb), 0.28);
+  --bs-table-hover-bg: rgba(var(--bs-success-rgb), 0.22);
+  --bs-table-striped-bg: rgba(var(--bs-success-rgb), 0.18);
+  --bs-table-active-bg: rgba(var(--bs-success-rgb), 0.24);
+}
+.table-info {
+  --bs-table-bg: rgba(var(--bs-info-rgb), 0.13);
+  --bs-table-border-color: rgba(var(--bs-info-rgb), 0.28);
+  --bs-table-hover-bg: rgba(var(--bs-info-rgb), 0.22);
+  --bs-table-striped-bg: rgba(var(--bs-info-rgb), 0.18);
+  --bs-table-active-bg: rgba(var(--bs-info-rgb), 0.24);
+}
+/* `.table-light` is used on the Monitor board for HEALTHY rows — semantically it
+   just means "no alert". Render it as the neutral default row (no glaring block);
+   the 🟢 marker already carries the signal. */
+.table-light {
+  --bs-table-bg: transparent;
+  --bs-table-border-color: var(--bs-border-color);
+  --bs-table-hover-bg: rgba(var(--bs-emphasis-color-rgb, 0, 0, 0), 0.04);
+  --bs-table-striped-bg: rgba(var(--bs-emphasis-color-rgb, 0, 0, 0), 0.03);
+  --bs-table-active-bg: rgba(var(--bs-emphasis-color-rgb, 0, 0, 0), 0.06);
+}
+
+/* ---------- Theme-aware neutral badges ----------------------------------- */
+/* `.badge.bg-light.text-dark` (workflow-type / external / private chips) is a
+   fixed light pill that glares on dark. Make it a subtle secondary-surface chip
+   that follows the theme. Colored badges (bg-danger/success/warning/info) are
+   intentional and left untouched. */
+.badge.bg-light.text-dark {
+  background-color: var(--bs-secondary-bg) !important;
+  color: var(--bs-body-color) !important;
+  border-color: var(--bs-border-color) !important;
+}

--- a/pages/_dash/actions.md
+++ b/pages/_dash/actions.md
@@ -137,7 +137,7 @@ registry repo and writes <code>_data/actions_usage.yml</code>, which this page r
   var WF = {{ a.workflows | jsonify }};
   if (!Array.isArray(WF) || !WF.length) return;
 
-// ---- cost-vs-effectiveness quadrant (canvas) ---- var cv = document.getElementById('quadrant'); if (cv && cv.getContext) {
+/* ---- cost-vs-effectiveness quadrant (canvas) ---- */ var cv = document.getElementById('quadrant'); if (cv && cv.getContext) {
     var ctx = cv.getContext('2d'), W = cv.width, H = cv.height,
         padL = 48, padR = 16, padT = 16, padB = 34;
     var maxMin = Math.max.apply(null, WF.map(function (w) { return w.total_min; })) || 1;
@@ -185,7 +185,7 @@ registry repo and writes <code>_data/actions_usage.yml</code>, which this page r
     });
   }
 
-// ---- type filter ---- var rows = Array.prototype.slice.call(document.querySelectorAll('#wf-table tbody tr')); document.querySelectorAll('#type-filter button').forEach(function (btn) {
+/* ---- type filter ---- */ var rows = Array.prototype.slice.call(document.querySelectorAll('#wf-table tbody tr')); document.querySelectorAll('#type-filter button').forEach(function (btn) {
     btn.addEventListener('click', function () {
       document.querySelectorAll('#type-filter button').forEach(function (b) { b.classList.remove('active'); });
       btn.classList.add('active');
@@ -194,7 +194,7 @@ registry repo and writes <code>_data/actions_usage.yml</code>, which this page r
     });
   });
 
-// ---- column sort ---- var tbody = document.querySelector('#wf-table tbody'), dir = {}; document.querySelectorAll('#wf-table th[data-sort]').forEach(function (th) {
+/* ---- column sort ---- */ var tbody = document.querySelector('#wf-table tbody'), dir = {}; document.querySelectorAll('#wf-table th[data-sort]').forEach(function (th) {
     th.style.cursor = 'pointer';
     th.addEventListener('click', function () {
       var key = th.getAttribute('data-sort'), num = key !== 'repo' && key !== 'type';


### PR DESCRIPTION
## What was broken

Reviewed every dash page in **light and dark mode**. Three issues, all fixed:

1. **Attention board / all `.table-*` tinted tables unreadable in dark mode** (the reported bug). Bootstrap's `.table-danger/.warning/.light` contextual classes ship **fixed light backgrounds**, so on the theme's dark surface Monitor/Triage/Actions rendered as glaring near-white blocks with washed-out text.
2. **Actions "Cost vs. effectiveness" chart was blank; filter + sort dead.** Three `// ---- section ---- ` comments sat on the same line as real code (`var cv = …`), commenting out the statements, unbalancing braces, and making the whole inline script fail to parse (`Unexpected identifier 'btn'`).
3. **Minor:** `.badge.bg-light.text-dark` chips glared as light pills on dark.

## Changes

- **`assets/css/user-overrides.css`** (new) — redefines the contextual table rows and neutral badges as **translucent, theme-aware tints** that composite over `--bs-body-bg`; legible in both themes. Healthy rows render neutral instead of a white block.
- **`_config.yml`** — `user_overrides: true`, the theme's hook to load that CSS last on every page.
- **`pages/_dash/actions.md`** — converted the three line comments to `/* … */` block comments so the code survives even if a formatter re-joins the lines.

## Verification

Against the **live deployed theme + Bootstrap**:
- Injected the exact CSS on Monitor → tables read correctly in **dark and light**.
- Re-ran the corrected Actions script live → quadrant chart drew **121,974 px** (was blank); filter/sort restored.
- `node --check` on the fixed script → parses clean.
- `schema_lint` → **0 errors**; `_config.yml` → valid YAML.

Pages already correct (Dashboard, Projects, Cockpit, AI Usage/Activity, Roadmap) were left untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)