### PR TITLE
fix(analytics): stop counting cancelled runs as failures

### DIFF
--- a/.github/scripts/dash-gen/actions_analytics.py
+++ b/.github/scripts/dash-gen/actions_analytics.py
@@ -14,6 +14,11 @@ while producing little? It groups consumption by workflow *type* and surfaces
 "high running, low effective" workflows quantitatively (cost = wall-clock minutes,
 value = share of minutes that end in success; waste = minutes on non-success runs).
 
+Cancelled runs are counted as waste (the minutes were really burned) but NOT as
+failures: `success_rate_pct` and the failing/flaky flags look only at runs that
+reached a verdict. Conflating the two made every workflow with a working
+`concurrency: cancel-in-progress` guard read as broken.
+
 Auth: a token from GH_TOKEN / GITHUB_TOKEN, else `gh auth token`. Network / rate
 -limit failures degrade gracefully (a repo that can't be read is skipped, not fatal).
 """
@@ -268,7 +273,15 @@ def build_report(registry: list[dict], gh, days: int, max_runs: int) -> dict:
                 "waste_min": round(b["waste_min"], 1),
                 "runs_per_week": round(b["runs"] / weeks, 1),
                 "success": b["success"], "failure": b["failure"], "cancelled": b["cancelled"],
-                "success_rate_pct": pct(b["success"], b["success"] + b["failure"] + b["cancelled"]),
+                # Cancelled runs are EXCLUDED from the denominator: a superseded
+                # run reached no verdict, so counting it as "not a success" made
+                # `success_rate_pct` measure churn instead of correctness, and
+                # the sub-50% result then tripped the `failing` flag on
+                # workflows with zero actual failures. Cancelled MINUTES still
+                # count as waste (they were really burned) — see waste_min — and
+                # the churn itself stays visible as cancel_pct / `cancel-heavy`.
+                "success_rate_pct": pct(b["success"], b["success"] + b["failure"]),
+                "cancel_pct": pct(b["cancelled"], b["success"] + b["failure"] + b["cancelled"]),
                 "effectiveness_pct": pct(b["success_min"], b["total_min"]) if b["total_min"] else 100.0,
                 "sched_pct": pct(sched, b["runs"]),
                 "events": b["events"],
@@ -290,7 +303,8 @@ def summarize(bucket: dict) -> dict:
         "total_min": round(bucket["total_min"], 1),
         "waste_min": round(bucket["waste_min"], 1),
         "effectiveness_pct": pct(bucket["success_min"], bucket["total_min"]) if bucket["total_min"] else 100.0,
-        "success_rate_pct": pct(bucket["success"], bucket["success"] + bucket["failure"] + bucket["cancelled"]),
+        # Cancelled excluded from the denominator — see the per-workflow record.
+        "success_rate_pct": pct(bucket["success"], bucket["success"] + bucket["failure"]),
     }
 
 
@@ -307,12 +321,17 @@ def finalize(workflows, inactive, by_type, by_repo, by_day, days, scanned, now) 
             continue
         flags = []
         completed = w["success"] + w["failure"] + w["cancelled"]
+        # Runs that actually reached a verdict. failing/flaky gate on THIS, not
+        # on `completed`: a workflow whose runs are merely superseded has no
+        # verdicts at all, and pct(0, 0) == 0.0 would otherwise read as "0%
+        # success" and flag it `failing` despite zero failures.
+        decided = w["success"] + w["failure"]
         if (w["total_min"] >= median_min and w["effectiveness_pct"] < LOW_EFFECTIVENESS
                 and w["waste_min"] >= MIN_WASTE_MIN):
             flags.append("high-cost-low-value")
-        if completed >= 3 and w["success_rate_pct"] < 50:
+        if decided >= 3 and w["success_rate_pct"] < 50:
             flags.append("failing")
-        elif completed >= 4 and 50 <= w["success_rate_pct"] < 85:
+        elif decided >= 4 and 50 <= w["success_rate_pct"] < 85:
             flags.append("flaky")
         if w["avg_min"] > SLOW_AVG_MIN:
             flags.append("slow")
@@ -345,7 +364,10 @@ def finalize(workflows, inactive, by_type, by_repo, by_day, days, scanned, now) 
 
     tot_runs = sum(w["runs"] for w in workflows)
     tot_success = sum(w["success"] for w in workflows)
-    tot_fail = sum(w["failure"] + w["cancelled"] for w in workflows)
+    # Failures only — cancelled runs reached no verdict and are excluded from
+    # the success rate, matching the per-workflow record. Their MINUTES still
+    # count in waste_min.
+    tot_fail = sum(w["failure"] for w in workflows)
     tot_waste = round(sum(w["waste_min"] for w in workflows), 1)
 
     return {
@@ -370,7 +392,10 @@ def finalize(workflows, inactive, by_type, by_repo, by_day, days, scanned, now) 
         "inactive": sorted(inactive, key=lambda x: (x["repo"], x["workflow"])),
         "note": ("Cost = wall-clock run minutes (run_started_at → updated_at), a proxy for "
                  "billable minutes. Value = share of minutes ending in success. "
-                 "Waste = minutes on failed/cancelled/timed-out runs."),
+                 "Waste = minutes on failed/cancelled/timed-out runs. "
+                 "Success rate counts only runs that reached a verdict "
+                 "(success + failure); cancelled runs were superseded, not broken, "
+                 "and show up as cancel_pct / the cancel-heavy flag instead."),
     }
 
 

--- a/.github/scripts/dash-gen/actions_review.py
+++ b/.github/scripts/dash-gen/actions_review.py
@@ -52,7 +52,10 @@ OUT_DEFAULT = REPO_ROOT / "actions-review-workorder.md"
 # Flags that make a workflow worth a reviewer's time (see actions_analytics).
 SERIOUS_FLAGS = {"failing", "flaky", "slow", "high-cost-low-value", "cancel-heavy"}
 # Which candidates want failing-run evidence vs slow-run evidence.
-FAILING_FLAGS = {"failing", "flaky", "cancel-heavy", "high-cost-low-value"}
+# `cancel-heavy` is deliberately absent: cancelled runs produce no failure logs,
+# so pulling `--log-failed` evidence for them sends the reviewer after runs that
+# never failed.
+FAILING_FLAGS = {"failing", "flaky", "high-cost-low-value"}
 
 
 # --------------------------------------------------------------------------- #
@@ -198,8 +201,13 @@ def angle(flags: list[str]) -> str:
         tips.append("most minutes end in non-success — gate the triggers or fix the "
                     "root failure so the spend produces value")
     if "cancel-heavy" in f:
-        tips.append("add `concurrency: {group, cancel-in-progress: true}` and/or narrower "
-                    "triggers so runs aren't superseded mid-flight")
+        # Do NOT suggest adding `cancel-in-progress: true` here — a high cancel
+        # share usually means the workflow ALREADY has it and is doing its job.
+        # Check first; the fix is to stop starting the run, not to cancel it later.
+        tips.append("check whether `cancel-in-progress: true` is already set — if so the "
+                    "cancellations are correct and the fix is to START fewer runs (narrower "
+                    "`paths:`/branch filters, fewer trigger `types:`, a job-level `if:` guard), "
+                    "not to add more cancelling")
     if "cron-heavy" in f:
         tips.append("reduce the `schedule` cadence or convert to event-driven triggers")
     return "; ".join(tips) or "review triggers, caching, and job structure for waste"

--- a/docs/WORKFLOW-OPTIMIZATION.md
+++ b/docs/WORKFLOW-OPTIMIZATION.md
@@ -4,6 +4,8 @@ A fleet-wide audit of every GitHub Actions workflow in the hub and its submodule
 
 Baseline: `_data/actions_usage.yml` (14-day window ending 2026-07-13) plus a static read of all workflow files in the checked-out submodules.
 
+> **Read the snapshot date before acting on a row.** The analytics refresh is daily, but a finding drawn from it can be stale by the time it is read — `it-journey` had already consolidated three auto-merge workflows into one after the snapshot above was taken. Always confirm a workflow still exists, and still looks the way the data implies, before opening work against it.
+
 ## Scope of the audit
 
 | | Count |
@@ -23,7 +25,8 @@ Measured consumption in the window: **3,290 minutes** across 1,594 runs, of whic
 The distinction drives every recommendation below, because the fixes are completely different:
 
 - **Structural waste** — the workflow is configured to do more work than it needs to: no dependency cache, a cron that fires more often than its inputs change, a missing concurrency guard, a job that exists only to spin a runner. Fixable by editing YAML. This is what was implemented.
-- **Failure waste** — the workflow is correctly configured but its runs fail. `zer0-mistakes/ci.yml` (528 lines, change-detection, matrix with `fail-fast: false`, npm caching, per-job timeouts) is *well* engineered; its 134 wasted minutes come from a 66% success rate, not from its config. Re-shaping it would not recover a minute. This class already has an owner — the `daily-repo-analysis.yml` loop opens a PR or files an issue per failing workflow — and is deliberately **not** addressed here.
+- **Failure waste** — the workflow is correctly configured but its runs fail. `zer0-mistakes/ci.yml` (528 lines, change-detection, matrix with `fail-fast: false`, npm caching, per-job timeouts) is *well* engineered; its 134 wasted minutes come from failing runs, not from its config. Re-shaping it would not recover a minute. This class already has an owner — the `daily-repo-analysis.yml` loop opens a PR or files an issue per failing workflow — and is deliberately **not** addressed here.
+- **Cancellation waste** — a third class, identified after the first pass and described under [Measurement](#measurement-the-success-rate-was-wrong) below. The minutes are real, but nothing is broken and there is nothing to fix in the workflow.
 
 Distinguishing them matters: 984 of the 1,271 wasted minutes are in the `ai` workflow type, whose runs are expensive by design. An AI loop that fails half its runs is a correctness problem, not a configuration problem.
 
@@ -92,9 +95,34 @@ The largest single line item in the fleet: 1,153 minutes over 15 runs (77 min av
 
 ### 5. Structural gaps worth a fan-out
 
-- `it-journey/content-auto-merge.yml` — 114 runs at 8% success, `cancel-heavy`. A `pull_request_target` auto-merge firing on every PR event and losing almost all of them.
-- `it-journey/dependabot-auto-merge.yml` — 30 wasted minutes over 35 runs, 67% success, `high-cost-low-value`. An auto-merge helper should cost seconds.
+- `it-journey/dependabot-auto-merge.yml` — 30 wasted minutes over 35 runs, `high-cost-low-value`. An auto-merge helper should cost seconds.
 - Missing `concurrency` on 24 workflows, and no path filters on 16 `push`/`pull_request` workflows — both are exactly what the `standardize-fanout.yml` channel exists to propagate.
+
+> `it-journey/content-auto-merge.yml` was listed here in the first pass as "114 runs at 8% success". That was the measurement bug below, not the workflow: it has **1 real failure**. It also already absorbed the separate `issue-pr-auto-merge.yml` and `quest-report-auto-merge.yml`, so the three-workflows-per-PR-event problem the analytics snapshot captured is already fixed upstream.
+
+## Measurement: the success rate was wrong
+
+The single most consequential finding, and the reason several entries above needed correcting.
+
+`success_rate_pct` was computed as `success / (success + failure + cancelled)`. Cancelled runs have no verdict — they were superseded by a newer commit, which is exactly what a `concurrency: cancel-in-progress: true` guard is *supposed* to do, and which the hub's own workflow standards mandate. Counting them as non-successes made the metric measure churn instead of correctness, and anything under 50% then tripped the **`failing`** flag.
+
+`failing` is in `SERIOUS_FLAGS`, so those workflows were nominated for the `actions-review` loop, where an **Opus** agent was dispatched to read `--log-failed` evidence for runs that had never failed. Replaying the corrected logic over the same data, six workflows change classification — and **four of them had zero actual failures**:
+
+| Workflow | ok / fail / cancelled | Old | New |
+| --- | --- | --- | --- |
+| `it-journey/agentic-quest-review.yml` | 3 / **0** / 8 | 27.3%, `failing` | **100%**, clean |
+| `zer0-mistakes/issue-autopilot.yml` | 8 / **0** / 11 | 42.1%, `failing` | **100%**, clean |
+| `it-journey/issue-pr-auto-merge.yml` | 0 / **0** / 27 | 0%, `failing` | no verdicts, clean |
+| `it-journey/content-auto-merge.yml` | 4 / 1 / 45 | 8.0%, `failing` | 80%, `flaky` |
+| `zer0-mistakes/ci.yml` | 40 / 7 / 14 | 65.6%, `flaky` | **85.1%**, clean |
+| `skills/vally-evaluation.lock.yml` | 0 / **0** / 6 | `failing` | no verdicts |
+
+Fixed in `.github/scripts/dash-gen/`:
+
+- `success_rate_pct` now counts only runs that reached a verdict (`success + failure`). Cancelled **minutes** still count in `waste_min` — they were really burned — and the churn stays visible as the new `cancel_pct` field and the existing `cancel-heavy` flag.
+- The `failing`/`flaky` flags gate on decided runs, not completed ones. Without this the fix is incomplete: `pct(0, 0)` returns `0.0`, so a workflow with only cancellations would still have read as "0% success" and stayed flagged.
+- `cancel-heavy` no longer pulls failing-run evidence in `actions_review.py` — cancelled runs produce no failure logs.
+- The reviewer's suggested angle for `cancel-heavy` no longer says "add `concurrency: cancel-in-progress: true`". That was self-contradictory: a high cancel share usually means the guard is already there and working. The advice is now to start fewer runs, not to cancel more.
 
 ## Verification
 


### PR DESCRIPTION
## Description

Follow-up to #40. Focusing on the high runners and largest waste surfaced a defect in the measurement itself — the thing that decides which workflows the optimization loop spends Opus minutes on.

`success_rate_pct` was `success / (success + failure + cancelled)`. A cancelled run reached **no verdict**: it was superseded by a newer commit, which is exactly what a `concurrency: cancel-in-progress: true` guard is supposed to do, and what [the hub's own workflow standards](.github/workflows/README.md) mandate. Counting those as non-successes made the metric measure churn instead of correctness — and anything under 50% then tripped the **`failing`** flag.

`failing` is in `SERIOUS_FLAGS`, so those workflows got nominated for the `actions-review` loop, where an **Opus** agent was dispatched to read `--log-failed` evidence for runs that had never failed. That is non-value-added processing in the most literal sense: expensive AI minutes spent investigating phantom failures, ending in issues filed against workflows that were working.

Replaying the corrected logic over the committed data, six workflows change classification — and **four had zero actual failures**:

| Workflow | ok / fail / cancelled | Old | New |
| --- | --- | --- | --- |
| `it-journey/agentic-quest-review.yml` | 3 / **0** / 8 | 27.3%, `failing` | **100%**, clean |
| `zer0-mistakes/issue-autopilot.yml` | 8 / **0** / 11 | 42.1%, `failing` | **100%**, clean |
| `it-journey/issue-pr-auto-merge.yml` | 0 / **0** / 27 | 0%, `failing` | no verdicts, clean |
| `it-journey/content-auto-merge.yml` | 4 / 1 / 45 | 8.0%, `failing` | 80%, `flaky` |
| `zer0-mistakes/ci.yml` | 40 / 7 / 14 | 65.6%, `flaky` | **85.1%**, clean |
| `skills/vally-evaluation.lock.yml` | 0 / **0** / 6 | `failing` | no verdicts |

### Changes

- **`success_rate_pct` counts only runs that reached a verdict** (`success + failure`) — per-workflow, per-bucket, and fleet totals. Cancelled **minutes** still count in `waste_min`, because they were really burned; the churn stays visible via the new `cancel_pct` field and the existing `cancel-heavy` flag. Waste totals are unchanged.
- **`failing`/`flaky` gate on decided runs, not completed ones.** Without this the fix is incomplete — `pct(0, 0)` returns `0.0`, so a workflow with *only* cancellations (like `issue-pr-auto-merge.yml`, 27 cancelled and nothing else) would still read as "0% success" and stay flagged.
- **`cancel-heavy` no longer pulls failing-run evidence** in `actions_review.py`. Cancelled runs produce no failure logs.
- **The reviewer's `cancel-heavy` angle no longer says "add `concurrency: cancel-in-progress: true`".** That was self-contradictory — a high cancel share usually means the guard is already there and doing its job. It now says to start fewer runs (narrower `paths:`/branch filters, fewer trigger `types:`, a job-level `if:`) rather than cancel more.

## Related Issues

- Follow-up to #40

## Type Of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Documentation update
- [ ] Maintenance or refactor
- [ ] Test improvement

## Verification

- [x] Corrected logic replayed over the real committed dataset — the six reclassifications above are measured, not predicted.
- [x] Both modules import and compile; `angle()` and `FAILING_FLAGS` verified at runtime.
- [x] `tools/check-drift.sh` passes ("✅ No drift").
- [x] `tools/unwrap-prose.py --check` — the doc changes comply.
- [x] Branch restarted from `main` after #40 squash-merged, carrying only the new commit.

## Notes For Reviewers

**This changes a displayed metric.** `/actions/` will show higher success rates after the next refresh — that is the point, but it means the numbers are not comparable to the currently committed `_data/actions_usage.yml` until `actions-usage.yml` regenerates it. `waste_min`, `total_min`, and `effectiveness_pct` are untouched.

**A judgment call worth checking:** cancelled minutes still count toward `waste_min`. They are genuinely burned minutes, so I kept them there — but they are *not* a defect to fix, since cancelling early saves more than letting the run finish. The doc now names this a third class of waste ("cancellation waste") alongside structural and failure waste, precisely so it stops being actioned as if it were a bug.

**Two corrections to #40's doc**, which repeated the miscomputed metric:
- `zer0-mistakes/ci.yml` was described as "66% success, flaky" — it is 85.1% with 7 real failures in 47 verdicts.
- `content-auto-merge.yml` was listed as "114 runs at 8% success" — it has **1** real failure. It had also already absorbed `issue-pr-auto-merge.yml` and `quest-report-auto-merge.yml` upstream, *after* the analytics snapshot the audit was based on. A staleness caveat is now at the top of the doc: confirm a workflow still exists and still looks the way the data implies before opening work against it.

**Unchanged from #40 and still submodule-owned:** `projects/skills` burning 350 min (10% of fleet minutes) on an external `microsoft/skills` mirror remains the largest recoverable block, and disabling Actions on the mirror is still zero-risk. `quest-perfection.yml` remains the largest single line item at 728 waste minutes; its 77-minute average is `max-parallel: 1` serializing slices by design, not misconfiguration, so it needs a reliability fix rather than a config one.

---
_Generated by [Claude Code](https://claude.ai/code/session_01LMU2wWXi5Kwj267ChmJqpe)_