### PR TITLE
chore: gitignore Playwright MCP browser artifacts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -177,3 +177,6 @@ _data/ai_activity.yml
 actions-review-workorder.md
 # Ephemeral failure work order (daily-repo-analysis gather → Claude Code agent)
 daily-analysis-workorder.md
+
+# Playwright MCP browser artifacts (screenshots, snapshots, downloads)
+.playwright-mcp/


### PR DESCRIPTION
Browser-automation sessions write screenshots, accessibility snapshots, console logs and downloads into `.playwright-mcp/`. These are per-session diagnostic artifacts, not repo content, and several capture admin-console views containing tenant identifiers.

The `bashconsultants` submodule already excludes this directory (its `CLAUDE.md` lists it under "Don't commit"); the root repo did not. In practice that meant the artifacts showed as untracked noise in `git status`, and when the tool's output directory reset mid-session, screenshots landed directly in the repo root instead — seven of them during a recent migration engagement.

One line in `.gitignore`. No other changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)