### PR TITLE
fix(ci): raise issue-pipeline tier-1 turn budget above full-capacity intake

### DIFF
--- a/.github/workflows/issue-pipeline.yml
+++ b/.github/workflows/issue-pipeline.yml
@@ -309,9 +309,13 @@ jobs:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           anthropic_api_key: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN == '' && secrets.ANTHROPIC_API_KEY || '' }}
           github_token: ${{ secrets.FLEET_TOKEN || secrets.GITHUB_TOKEN }}
+          # Turn budget must clear a FULL-capacity intake run: tiers.intake.max_issues (8)
+          # issues plus evidence.max_runs (6) bundles to read. A run at exactly that
+          # capacity measured 182 turns, so the previous 150 failed the job after the
+          # work had already succeeded. Raise the caps in _data/fleet.yml together.
           claude_args: >-
             --model opus
-            --max-turns 150
+            --max-turns 250
             --allowedTools "Bash(gh:*),Bash(cat:*),Bash(ls:*),Bash(jq:*),Bash(sed:*),Bash(head:*),Bash(tail:*),Bash(tools/issue-evidence.sh:*),Read,Grep,Glob,Write"
           prompt: |
             You are **tier 1** of the bamr87 fleet's issue pipeline: INTAKE. A


### PR DESCRIPTION
<!-- fleet-doctor key="bamr87/bamr87:.github/workflows/issue-pipeline.yml" -->

## Problem

**Repo:** `bamr87/bamr87` · **Workflow:** `.github/workflows/issue-pipeline.yml` · **Signals:** `failing`

The scheduled run on 2026-08-13 failed in **Tier 1 · intake & evidence**. Everything up to and including evidence collection succeeded — the job's step list shows `Build evidence bundles` ✓ and `Upload evidence bundles` ✓ — and only the `Enrich issues` step went red:

```
##[error]Claude reported a successful result after 182 turns, exceeding the configured maximum of 150
##[error]Action failed with error: Claude reported a successful result after 182 turns, exceeding the configured maximum of 150
##[error]Process completed with exit code 1.
```

Note the wording: **"reported a successful result"**. The intake work finished. The job was failed afterwards by the turn guard, so the red does not indicate a broken tier — it indicates a mis-sized budget.

Downstream, Tier 3 was skipped (`Tier 3 · complete & ready for review in 0s`), so one undersized guard costs the pipeline its final stage.

## Root cause

`--max-turns 150` on the Tier 1 `anthropics/claude-code-action@v1` call (line 314) is set below what a **full-capacity** intake run actually costs.

The failing run was at exactly the capacity `_data/fleet.yml` permits:

| `_data/fleet.yml` key | value | that run |
| --- | --- | --- |
| `issue_pipeline.tiers.intake.max_issues` | 8 | `Queue: 8 issue(s)` |
| `issue_pipeline.evidence.max_runs` | 6 | `Evidence bundles built: 6` |

So 182 turns is not an outlier — it is roughly what this tier costs when the queue is full, and the queue is allowed to be full on any run.

The budget was also the **lowest of the three tiers** despite Tier 1 doing the widest sweep. Tier 1 reads 8 issues plus 6 evidence bundles (each with `evidence.md`, `evidence.json`, `candidates.md`, `logs/`, and a real checkout to `Read`/`Grep`), while tiers 2 and 3 handle 3 and 4 items respectively:

| Tier | Items per run | `--max-turns` (before) |
| --- | --- | --- |
| 1 · intake | 8 issues + 6 bundles | **150** |
| 2 · implement | 3 PRs | 200 |
| 3 · complete | 4 PRs | 200 |

## Fix

Raise the Tier 1 budget `150 → 250`, and add a comment recording what the number is derived from so it isn't "tidied" back down to match its siblings.

250 rather than 200: the observed full-capacity peak is 182, so 200 leaves only ~10% headroom and would flap on the next slightly-heavier queue. 250 is ~37% above the measured peak.

This does not weaken any gate. `--max-turns` is a cost guard, not a correctness check — no `continue-on-error`, no retry, and no change to what Tier 1 is allowed to do. Runtime is bounded independently by `timeout-minutes: 90` on the job, against which the failing step used 26m16s, so the higher turn ceiling has ample room before the real ceiling binds.

## Expected impact

Tier 1 stops failing after succeeding, and Tier 3 stops being skipped as collateral. No additional minutes are consumed on a healthy run — turns are only spent if the queue actually needs them.

## Links

- Failing run: https://github.com/bamr87/bamr87/actions/runs/31682650251
- Dash Actions analytics: https://bamr87.github.io/bamr87/actions/
- Pipeline docs: [`docs/ISSUE-PIPELINE.md`](https://github.com/bamr87/bamr87/blob/main/docs/ISSUE-PIPELINE.md)
