### PR TITLE
fix(ci): unbreak nightly submodule sync + daily local workspace sync

### DIFF
--- a/.github/workflows/update-submodules.yml
+++ b/.github/workflows/update-submodules.yml
@@ -1,5 +1,12 @@
 name: 🔀 Update Submodules
 
+# Requires FLEET_TOKEN (see _data/fleet.yml) for two reasons:
+#   - GITHUB_TOKEN 404s on the fleet's private submodules, so a recursive
+#     checkout with it dies before the update step ever runs.
+#   - A PR opened with GITHUB_TOKEN fires no workflow events, so the required
+#     drift gate never runs and the PR is unmergeable on protected main.
+# Both call sites fall back to GITHUB_TOKEN (degraded: public repos only).
+
 on:
   schedule:
     - cron: '0 3 * * *'
@@ -32,17 +39,21 @@ jobs:
       pull-requests: write
 
     steps:
+      # submodules: false — a recursive checkout hard-fails the whole job when
+      # one submodule repo is private-to-the-token or gone (renamed/deleted).
+      # The update step below inits each submodule itself and degrades those
+      # to per-path warnings instead.
       - name: Checkout repository
         uses: actions/checkout@v7
         with:
-          submodules: recursive
+          submodules: false
           fetch-depth: 0
-          token: ${{ secrets.GITHUB_TOKEN }}
+          token: ${{ secrets.FLEET_TOKEN || secrets.GITHUB_TOKEN }}
 
       - name: Configure Git
         uses: ./.github/actions/setup/configure-git
         with:
-          github-token: ${{ secrets.GITHUB_TOKEN }}
+          github-token: ${{ secrets.FLEET_TOKEN || secrets.GITHUB_TOKEN }}
 
       - name: Update submodules
         id: update
@@ -80,8 +91,10 @@ jobs:
           fi
 
           # Stage ONLY submodule pointer changes — never stray root-tree edits.
+          # A path whose repo was unreachable is still an empty dir here; adding
+          # it is a no-op, but don't let one bad path abort the loop.
           git config --file .gitmodules --get-regexp path | awk '{ print $2 }' \
-            | while IFS= read -r p; do git add -- "$p"; done
+            | while IFS= read -r p; do git add -- "$p" || echo "::warning::could not stage ${p}"; done
 
           if git diff --cached --quiet; then
             echo "changed=false" >> "$GITHUB_OUTPUT"
@@ -98,7 +111,8 @@ jobs:
         if: steps.update.outputs.changed == 'true'
         uses: peter-evans/create-pull-request@v8
         with:
-          token: ${{ secrets.GITHUB_TOKEN }}
+          # FLEET_TOKEN so the PR fires workflow events and the drift gate runs.
+          token: ${{ secrets.FLEET_TOKEN || secrets.GITHUB_TOKEN }}
           commit-message: "chore(submodule): update ${{ inputs.submodule || 'all' }} submodule pointer(s)"
           title: "chore(submodule): update ${{ inputs.submodule || 'all' }} submodule pointer(s)"
           body: |

--- a/tools/README.md
+++ b/tools/README.md
@@ -15,6 +15,7 @@ This directory contains cross-platform scripts for bootstrapping, configuring, a
 | `Brewfile` | macOS Homebrew bundle — native `brew bundle` format (derived from manifest) |
 | `setup.sh` | **Primary entrypoint** — cross-platform dev environment setup |
 | `update-submodules.sh` | Refresh `projects/` — bring each submodule onto its declared branch at the remote tip (safe by default) and record moved pointers |
+| `install-workspace-sync.sh` | Installs the `com.bamr87.workspace-sync` LaunchAgent (macOS) that runs `update-submodules.sh --no-commit --no-push` daily and at login, keeping the local clone on `main` everywhere — pointer recording stays with the `update-submodules.yml` PR (`--uninstall` removes it) |
 | `dash` | Unified dash CLI (`status`, `monitor`, `serve`, `sync`, `ai`, `gen`, …) — see [docs/DASH.md](../docs/DASH.md) |
 | `dash-gen` | Wrapper for the registry generator (`health`, `readme`, `ai`, `ai-usage`, `actions`, `daily`, `triage`, `remediate`, `reconcile`, `estimate`, `ledger`, `all`) in [.github/scripts/dash-gen/](../.github/scripts/dash-gen/) |
 | `fleet-config.py` | Reads [`_data/fleet.yml`](../_data/fleet.yml), the fleet's central config. `audit` (= `dash secrets`) prints the per-repo matrix of declared secrets/variables vs what GitHub actually has; `sync --apply` (= `dash config sync`) projects the canonical repo **variables** onto every fleet repo; `show [dotted.key]` reads a value. Secret *values* are never read or stored — `gh` returns names only. |

--- a/tools/install-workspace-sync.sh
+++ b/tools/install-workspace-sync.sh
@@ -1,0 +1,109 @@
+#!/usr/bin/env bash
+#
+# install-workspace-sync.sh — keep this clone automatically in sync, daily
+#
+# Installs a per-user macOS LaunchAgent (com.bamr87.workspace-sync) that, every
+# day and at every login, brings the local workspace current:
+#
+#   1. fast-forwards the hub repo (only when checked out on main)
+#   2. runs tools/update-submodules.sh --no-commit --no-push, which puts every
+#      submodule ON its declared branch at the latest remote commit (dirty or
+#      diverged submodules are skipped, never reset)
+#   3. unstages the moved pointers — recording them is owned by the daily
+#      update-submodules.yml PR, so local main never diverges from the
+#      protected branch
+#
+# launchd runs missed jobs after wake, so a closed laptop syncs on next login.
+# Output is appended to ~/Library/Logs/bamr87-workspace-sync.log.
+#
+# Usage:
+#   tools/install-workspace-sync.sh [--hour N]   # install/update (default 07:00)
+#   tools/install-workspace-sync.sh --uninstall  # remove the agent
+#
+
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+LABEL="com.bamr87.workspace-sync"
+PLIST="${HOME}/Library/LaunchAgents/${LABEL}.plist"
+LOG="${HOME}/Library/Logs/bamr87-workspace-sync.log"
+HOUR=7
+UNINSTALL=false
+
+while [[ $# -gt 0 ]]; do
+    case $1 in
+        --uninstall) UNINSTALL=true; shift ;;
+        --hour)      HOUR="${2:?--hour needs a value}"; shift 2 ;;
+        -h|--help)   sed -n '2,22p' "${BASH_SOURCE[0]}" | sed 's/^# \{0,1\}//'; exit 0 ;;
+        *)           echo "unknown option: $1" >&2; exit 1 ;;
+    esac
+done
+
+[[ "$(uname)" == "Darwin" ]] || { echo "launchd is macOS-only; on Linux use cron/systemd instead" >&2; exit 1; }
+
+uid="$(id -u)"
+
+if [[ "$UNINSTALL" == true ]]; then
+    launchctl bootout "gui/${uid}/${LABEL}" 2>/dev/null || true
+    rm -f "$PLIST"
+    echo "Removed ${LABEL}."
+    exit 0
+fi
+
+mkdir -p "${HOME}/Library/LaunchAgents" "${HOME}/Library/Logs"
+
+cat > "$PLIST" <<EOF
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>Label</key>
+    <string>${LABEL}</string>
+
+    <key>ProgramArguments</key>
+    <array>
+        <string>/bin/zsh</string>
+        <string>-lc</string>
+        <string>
+cd ${ROOT} || exit 1
+export PATH=/opt/homebrew/bin:/usr/local/bin:\$PATH
+echo "=== workspace-sync \$(date) ==="
+if [ "\$(git symbolic-ref --short -q HEAD)" = main ]; then
+  git pull --ff-only --quiet || echo "[WARN] root pull skipped (non-ff or offline)"
+else
+  echo "[INFO] root not on main; skipping root pull"
+fi
+tools/update-submodules.sh --no-commit --no-push
+git reset --quiet -- projects .gitmodules
+echo "=== workspace-sync done \$(date) ==="
+        </string>
+    </array>
+
+    <key>StartCalendarInterval</key>
+    <dict>
+        <key>Hour</key>
+        <integer>${HOUR}</integer>
+        <key>Minute</key>
+        <integer>0</integer>
+    </dict>
+
+    <key>RunAtLoad</key>
+    <true/>
+
+    <key>ProcessType</key>
+    <string>Background</string>
+
+    <key>StandardOutPath</key>
+    <string>${LOG}</string>
+    <key>StandardErrorPath</key>
+    <string>${LOG}</string>
+</dict>
+</plist>
+EOF
+
+# Reload cleanly whether or not a previous version was bootstrapped.
+launchctl bootout "gui/${uid}/${LABEL}" 2>/dev/null || true
+launchctl bootstrap "gui/${uid}" "$PLIST"
+
+echo "Installed ${LABEL}: daily at $(printf '%02d:00' "$HOUR") + every login (RunAtLoad)."
+echo "Log: ${LOG}"

--- a/tools/setup.sh
+++ b/tools/setup.sh
@@ -766,6 +766,16 @@ setup_submodules() {
 
     cd "$PROJECT_ROOT"
 
+    # Workspace-local git config: fetch/pull/checkout recurse into submodules
+    # automatically, pushes refuse to publish a pointer whose submodule commit
+    # isn't pushed, and status/diff stay submodule-aware.
+    run_cmd git config submodule.recurse true
+    run_cmd git config fetch.recurseSubmodules on-demand
+    run_cmd git config push.recurseSubmodules check
+    run_cmd git config submodule.fetchJobs 8
+    run_cmd git config status.submodulesummary true
+    run_cmd git config diff.submodule log
+
     run_cmd git submodule sync --recursive
     run_cmd git submodule update --init --recursive
 


### PR DESCRIPTION
## What

Two halves of the same goal — **the workspace stays on `main` everywhere, automatically, daily**:

### 1. Unbreak the nightly `update-submodules.yml` (failing since at least 2026-08-16)

The job died at checkout every night: `submodules: recursive` with `GITHUB_TOKEN` hard-fails on the fleet's ~9 private repos (books, cv, cv-builder-pro, drsai, gitorio, law-ai, zer0-image-generator, zer0-pages-remote, zpl-viewer) — "Repository not found" — before the tolerant per-path update step ever ran.

- Checkout no longer recurses; the update step already inits each submodule with per-path warnings, so an unreachable repo (private or genuinely gone, e.g. `amrs-project`) degrades instead of killing the job.
- Checkout + `create-pull-request` now use `FLEET_TOKEN || GITHUB_TOKEN`, per the standing rules: GITHUB_TOKEN can't see private fleet repos, and a PR it opens fires no workflow events, so the required drift gate never ran on pointer-bump PRs.
- Staging loop no longer aborts on a path that failed to init.

### 2. Local workspace: automatic + daily

- `tools/setup.sh` now provisions submodule-aware git config on bootstrap (`submodule.recurse`, `fetch.recurseSubmodules on-demand`, `push.recurseSubmodules check`, 8 fetch jobs, submodule-aware status/diff).
- New `tools/install-workspace-sync.sh` installs a `com.bamr87.workspace-sync` LaunchAgent: daily at 07:00 + every login, it ff-pulls the hub (only on `main`) and runs `update-submodules.sh --no-commit --no-push`, leaving pointer recording to this workflow's PR so local `main` never diverges from the protected branch. Already installed and verified green on this machine (log: `~/Library/Logs/bamr87-workspace-sync.log`).

## Verification

- `actionlint` clean; `shellcheck --severity=warning` clean; `schema_lint check tools` PASS (new script rides the `*.sh` pattern row); tools/README.md row added.
- First LaunchAgent run completed: all 35 submodules `declared=main on=main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
