### PR TITLE
Add reusable resolve-fleet-token composite action (token preflight probe)

### DIFF
--- a/.github/actions/resolve-fleet-token/README.md
+++ b/.github/actions/resolve-fleet-token/README.md
@@ -1,0 +1,99 @@
+# `resolve-fleet-token`
+
+Pick the first GitHub token that **works**, not the first one that happens to be
+non-empty.
+
+## Why
+
+The common pattern for token selection is a three-way fallback:
+
+```yaml
+env:
+  GH_TOKEN: ${{ secrets.FLEET_TOKEN || secrets.GH_PAT || github.token }}
+```
+
+`||` selects the first non-empty operand and performs no validity check. That is
+fine when every candidate is equally capable, but it fails quietly in two common
+situations:
+
+- an **expired or revoked PAT** is still a non-empty string, so it wins the
+  `||` chain and then returns `401` on the first real API call;
+- the job-scoped **`GITHUB_TOKEN` is repo-scoped**, so against a *foreign*
+  repository it returns `404 Not Found`, not `403 Forbidden`. The failure looks
+  like "that repo/issue doesn't exist" rather than "you aren't allowed", which
+  sends debugging in the wrong direction.
+
+This action probes each candidate with an idempotent
+`GET /repos/{owner}/{repo}` and hands back the first one that returns `200`.
+
+## Usage
+
+```yaml
+- id: token
+  uses: ./.github/actions/resolve-fleet-token
+  with:
+    fleet-token: ${{ secrets.FLEET_TOKEN }}
+    fallback-token: ${{ secrets.GH_PAT }}
+    default-token: ${{ github.token }}
+    probe-repo: some-org/some-other-repo
+
+- name: Do cross-repo work
+  run: gh issue list --repo some-org/some-other-repo
+  env:
+    GH_TOKEN: ${{ steps.token.outputs.token }}
+```
+
+Set `probe-repo` to the repository the job actually intends to touch. Probing
+the current repository proves nothing about cross-repo access.
+
+To branch instead of failing:
+
+```yaml
+- id: token
+  uses: ./.github/actions/resolve-fleet-token
+  with:
+    fleet-token: ${{ secrets.FLEET_TOKEN }}
+    default-token: ${{ github.token }}
+    probe-repo: some-org/some-other-repo
+    fail-on-no-valid-token: 'false'
+
+- if: steps.token.outputs.valid == 'true'
+  run: ...
+```
+
+## Inputs
+
+| Input | Default | Description |
+| --- | --- | --- |
+| `fleet-token` | `''` | Primary candidate. |
+| `fleet-token-name` | `FLEET_TOKEN` | Name reported in `source`. |
+| `fallback-token` | `''` | Second candidate. |
+| `fallback-token-name` | `FALLBACK_TOKEN` | Name reported in `source`. |
+| `default-token` | `''` | Last resort, normally `${{ github.token }}`. |
+| `default-token-name` | `GITHUB_TOKEN` | Name reported in `source`. |
+| `probe-repo` | `${{ github.repository }}` | `owner/repo` used for the probe. |
+| `api-url` | `${{ github.api_url }}` | API base URL. |
+| `fail-on-no-valid-token` | `'true'` | Fail the step when nothing validates. |
+
+## Outputs
+
+| Output | Description |
+| --- | --- |
+| `token` | The validated token, or empty when none validated. |
+| `source` | Name of the secret the winning token came from. |
+| `valid` | `'true'` or `'false'`. |
+
+## When *not* to use it
+
+For **same-repo** work, keep the plain `||` fallback. `GITHUB_TOKEN` is
+genuinely sufficient there, and adding a network round-trip per job to confirm
+something the platform already guarantees is not worth the latency.
+
+## Safety notes
+
+- Every non-empty candidate is `::add-mask::`ed *before* any probe runs, so even
+  a rejected candidate cannot appear in logs.
+- The probe is a read-only `GET`; re-running it has no side effects.
+- Only the HTTP status code is captured; the response body goes to `/dev/null`.
+- Tokens are passed to the script through `env:`, never interpolated into the
+  script body.

--- a/.github/actions/resolve-fleet-token/action.yml
+++ b/.github/actions/resolve-fleet-token/action.yml
@@ -1,0 +1,190 @@
+name: Resolve fleet token
+description: >-
+  Select the first GitHub token that actually works against a probe repository,
+  instead of the first one that merely happens to be non-empty. Every candidate
+  is masked before use and validated with an idempotent GET /repos/{owner}/{repo}.
+
+inputs:
+  fleet-token:
+    description: >-
+      Primary candidate token, e.g. secrets.FLEET_TOKEN. May be empty.
+    required: false
+    default: ''
+  fleet-token-name:
+    description: >-
+      Human-readable name reported in the `source` output when the primary
+      candidate wins. Used for logging only; never the token value itself.
+    required: false
+    default: FLEET_TOKEN
+  fallback-token:
+    description: >-
+      Second candidate token, e.g. a personal access token. May be empty.
+    required: false
+    default: ''
+  fallback-token-name:
+    description: Human-readable name for the second candidate.
+    required: false
+    default: FALLBACK_TOKEN
+  default-token:
+    description: >-
+      Last-resort candidate, normally ${{ github.token }}. Note that the
+      job-scoped GITHUB_TOKEN cannot read foreign repositories and will probe
+      as 404 when `probe-repo` is not this repository.
+    required: false
+    default: ''
+  default-token-name:
+    description: Human-readable name for the last-resort candidate.
+    required: false
+    default: GITHUB_TOKEN
+  probe-repo:
+    description: >-
+      owner/repo used for the validity probe. Set this to the repository the
+      caller actually intends to touch, otherwise the probe proves nothing
+      about cross-repo access.
+    required: false
+    default: ${{ github.repository }}
+  api-url:
+    description: GitHub API base URL.
+    required: false
+    default: ${{ github.api_url }}
+  fail-on-no-valid-token:
+    description: >-
+      When 'true' (default) the step fails if no candidate validates. Set to
+      'false' to branch on the `valid` output instead.
+    required: false
+    default: 'true'
+
+outputs:
+  token:
+    description: >-
+      The first candidate that returned HTTP 200 for the probe repository.
+      Empty when no candidate validated and fail-on-no-valid-token is 'false'.
+    value: ${{ steps.resolve.outputs.token }}
+  source:
+    description: >-
+      Name of the secret the winning token came from, e.g. FLEET_TOKEN.
+      Empty when no candidate validated.
+    value: ${{ steps.resolve.outputs.source }}
+  valid:
+    description: "'true' when a candidate validated, otherwise 'false'."
+    value: ${{ steps.resolve.outputs.valid }}
+
+runs:
+  using: composite
+  steps:
+    - id: resolve
+      shell: bash
+      env:
+        FLEET_TOKEN: ${{ inputs.fleet-token }}
+        FLEET_TOKEN_NAME: ${{ inputs.fleet-token-name }}
+        FALLBACK_TOKEN: ${{ inputs.fallback-token }}
+        FALLBACK_TOKEN_NAME: ${{ inputs.fallback-token-name }}
+        DEFAULT_TOKEN: ${{ inputs.default-token }}
+        DEFAULT_TOKEN_NAME: ${{ inputs.default-token-name }}
+        PROBE_REPO: ${{ inputs.probe-repo }}
+        API_URL: ${{ inputs.api-url }}
+        FAIL_ON_NO_VALID_TOKEN: ${{ inputs.fail-on-no-valid-token }}
+      run: |
+        # No `set -e`: a failing curl is an expected outcome that we handle by
+        # falling through to the next candidate, not a reason to abort the step.
+        set -uo pipefail
+
+        names=("$FLEET_TOKEN_NAME" "$FALLBACK_TOKEN_NAME" "$DEFAULT_TOKEN_NAME")
+        values=("$FLEET_TOKEN" "$FALLBACK_TOKEN" "$DEFAULT_TOKEN")
+
+        # Mask every candidate up front, before any of them is used. Rejected
+        # candidates are masked too, so a failed probe cannot leak a secret.
+        for value in "${values[@]}"; do
+          if [ -n "$value" ]; then
+            echo "::add-mask::${value}"
+          fi
+        done
+
+        if [ -z "${API_URL}" ]; then
+          API_URL="https://api.github.com"
+        fi
+        API_URL="${API_URL%/}"
+
+        if [ -z "${PROBE_REPO}" ]; then
+          echo "::error::resolve-fleet-token: probe-repo is empty; nothing to validate against."
+          exit 1
+        fi
+
+        # Idempotent, side-effect-free read. Only the status code is captured;
+        # the response body is discarded so no token-adjacent data is printed.
+        probe() {
+          local token="$1"
+          curl -sS \
+            -o /dev/null \
+            -w '%{http_code}' \
+            -X GET \
+            -H "Authorization: Bearer ${token}" \
+            -H "Accept: application/vnd.github+json" \
+            -H "X-GitHub-Api-Version: 2022-11-28" \
+            --max-time 15 \
+            --retry 2 \
+            --retry-connrefused \
+            "${API_URL}/repos/${PROBE_REPO}" 2>/dev/null || echo '000'
+        }
+
+        winning_token=''
+        winning_source=''
+
+        echo "Probing token candidates against ${PROBE_REPO}:"
+        for i in "${!values[@]}"; do
+          name="${names[$i]}"
+          value="${values[$i]}"
+
+          if [ -z "$value" ]; then
+            echo "  - ${name}: not set, skipping"
+            continue
+          fi
+
+          status="$(probe "$value")"
+          case "$status" in
+            200)
+              echo "  - ${name}: ok (200)"
+              winning_token="$value"
+              winning_source="$name"
+              break
+              ;;
+            401)
+              echo "  - ${name}: rejected (401) - token is expired, revoked or malformed"
+              ;;
+            403)
+              echo "  - ${name}: forbidden (403) - authenticated but insufficient scope, or rate limited"
+              ;;
+            404)
+              echo "  - ${name}: not visible (404) - this token cannot see ${PROBE_REPO}; a repo-scoped GITHUB_TOKEN returns 404, not 403, for foreign repositories"
+              ;;
+            000)
+              echo "  - ${name}: network error contacting ${API_URL}"
+              ;;
+            *)
+              echo "  - ${name}: unexpected status ${status}"
+              ;;
+          esac
+        done
+
+        if [ -n "$winning_token" ]; then
+          {
+            echo "token=${winning_token}"
+            echo "source=${winning_source}"
+            echo "valid=true"
+          } >> "$GITHUB_OUTPUT"
+          echo "Using ${winning_source} for ${PROBE_REPO}."
+          exit 0
+        fi
+
+        {
+          echo "token="
+          echo "source="
+          echo "valid=false"
+        } >> "$GITHUB_OUTPUT"
+
+        if [ "${FAIL_ON_NO_VALID_TOKEN}" = 'true' ]; then
+          echo "::error::resolve-fleet-token: no candidate token can read ${PROBE_REPO}. See the per-candidate status codes above."
+          exit 1
+        fi
+
+        echo "::warning::resolve-fleet-token: no candidate token can read ${PROBE_REPO}; continuing because fail-on-no-valid-token is not 'true'."


### PR DESCRIPTION
## What

Adds a new composite action at `.github/actions/resolve-fleet-token/action.yml` (plus a short README) that resolves a working GitHub token instead of merely a non-empty one.

Given up to three candidates (`fleet-token`, `fallback-token`, `default-token`) it:

1. `::add-mask::`es **every** non-empty candidate before any of them is used, so a token can never surface in a log line even if a probe fails or the step errors later;
2. validates each candidate in order with an idempotent, side-effect-free `GET {api-url}/repos/{probe-repo}`;
3. outputs the first candidate that returns HTTP 200, together with `source` (the human-readable secret name it came from) and `valid`.

Status codes are reported distinctly, because they mean different things and are the whole reason the plain `||` chain is unsafe:

- `401` — token is expired/revoked/malformed;
- `403` — authenticated but insufficient scope, or rate limited;
- `404` — the token cannot *see* the probe repo at all. A repo-scoped `GITHUB_TOKEN` pointed at a foreign repository returns 404, not 403, so a plain `||` fallback silently "succeeds" at selection time and then fails deep inside a later API call with a confusing not-found error.

`fail-on-no-valid-token` (default `true`) makes the failure loud and early; set it to `false` when a caller wants to branch on `steps.<id>.outputs.valid` instead.

## Scope / what this PR deliberately does *not* do

This PR is **purely additive**. No existing workflow file is modified, so every current job keeps its present token-selection behavior byte for byte.

Two follow-ups from the original TODO are intentionally left out:

- **Verbatim extraction from `issue-pipeline.yml`.** The TODO says that if `issue-pipeline.yml` already contains a working preflight probe, it should be lifted verbatim rather than reimplemented. I did not have that file's contents available in this run, so I did not want to assert anything about it. If a probe already lives there, the right move is to replace the `Probe candidate tokens` step body in this action with that script verbatim and delete the inline copy — the action's input/output contract is designed to accommodate that swap without changing callers.
- **Converting call sites.** Per the TODO, only jobs that do genuine *cross-repo* work should adopt this action; same-repo jobs should stay on the plain fallback because `GITHUB_TOKEN` is genuinely sufficient there. Deciding which is which requires reading the actual workflow files, so I left that for a targeted follow-up (filed as `discovered`) rather than guessing.

## Usage

```yaml
- id: token
  uses: ./.github/actions/resolve-fleet-token
  with:
    fleet-token: ${{ secrets.FLEET_TOKEN }}
    fallback-token: ${{ secrets.GH_PAT }}
    default-token: ${{ github.token }}
    probe-repo: some-org/some-other-repo

- run: gh issue list --repo some-org/some-other-repo
  env:
    GH_TOKEN: ${{ steps.token.outputs.token }}
```

## How I verified it

This is a new file with no callers, so verification was by reading the script rather than by running the pipeline:

- **Masking happens before any use.** The first loop over `names`/`values` emits `::add-mask::` for every non-empty candidate, and it completes before the probe loop starts — so even the *rejected* candidates are masked, not just the winner.
- **The probe is read-only and idempotent.** `curl -X GET` against `/repos/{owner}/{repo}` with `-o /dev/null -w '%{http_code}'`; nothing is written and re-running is free. `--max-time 15` and `--retry 2` bound the cost of a hung endpoint.
- **No token reaches stdout.** `curl -sS` sends the body to `/dev/null`; only the status code is captured. The winning token goes to `$GITHUB_OUTPUT` (not logged) and is masked besides.
- **Shell safety.** `set -uo pipefail` without `-e`, because a non-zero `curl` exit is an expected outcome that the `|| echo '000'` fallback handles; with `-e` a network blip would abort the step instead of falling through to the next candidate. Every expansion is quoted, and tokens are passed through `env:` rather than interpolated into the script body, so a token containing shell metacharacters cannot break out.
- **Contract wiring.** The three `outputs:` at the top level reference `steps.resolve.outputs.*`, and the script writes exactly `token`, `source`, and `valid` to `$GITHUB_OUTPUT` on both the success and the no-valid-token paths — so `outputs.valid` is always defined when `fail-on-no-valid-token: false`.

A reviewer with the workflow files in hand should confirm the `issue-pipeline.yml` reconciliation noted above before adopting this in any job.

---
🤖 wtd fleet · `contributor` agent · item `bamr87/bamr87:improve_code:e582d1cac8c9`
<!-- wtd-fleet:bamr87/bamr87:improve_code:e582d1cac8c9 -->