### PR TITLE
docs: add a local development guide (Docker + Jekyll) for newcomers

### DIFF
--- a/docs/local-development.md
+++ b/docs/local-development.md
@@ -1,0 +1,248 @@
+---
+title: Local Development Guide
+description: How to clone, configure and run this monorepo locally with Docker or Bundler + Jekyll.
+---
+
+# Local Development Guide
+
+This guide gets a newcomer from `git clone` to a site running on their machine.
+
+`README.md` at the root of this repository is a **profile README** — it describes the
+author, not the repository's build. This document covers the repository itself.
+
+> **Note on accuracy:** every command below is either a standard tool command or a
+> *discovery* command that prints the repository's real configuration. Where a value
+> is specific to this repo and needs a maintainer to confirm it, you'll see a
+> `TODO (maintainer)` callout. Please replace those with concrete values rather than
+> guessing.
+
+---
+
+## 1. Prerequisites
+
+Pick **one** of the two paths below. You do not need both.
+
+| Path | You need |
+| --- | --- |
+| **Docker** (recommended for a first run) | Docker Desktop / Docker Engine with the `docker compose` plugin |
+| **Native Ruby** | Ruby + Bundler (`gem install bundler`) |
+| **Dev Container** (VS Code) | VS Code + the *Dev Containers* extension + Docker |
+
+The repository ships a `.devcontainer/` directory, so VS Code will offer to
+"Reopen in Container" when you open the folder. That path handles the toolchain
+for you.
+
+Other tooling present at the root that you may want installed:
+
+- `.pre-commit-config.yaml` — [pre-commit](https://pre-commit.com/) hooks
+- `.editorconfig`, `.prettierrc`, `.prettierignore` — editor and formatting config
+
+---
+
+## 2. Clone the repository (with submodules)
+
+This repository uses git submodules — there is a `.gitmodules` file at the root.
+If you clone without them, parts of the tree will be empty directories.
+
+```bash
+git clone --recurse-submodules https://github.com/bamr87/bamr87.git
+cd bamr87
+```
+
+Already cloned without `--recurse-submodules`? Fix it in place:
+
+```bash
+git submodule update --init --recursive
+```
+
+To see which submodules are configured and where they point:
+
+```bash
+cat .gitmodules
+git submodule status
+```
+
+📖 See [`SUBMODULES.md`](../SUBMODULES.md) for this repository's own guidance on
+adding, updating and troubleshooting submodules — treat it as the authoritative
+source over this section.
+
+---
+
+## 3. Configure your environment
+
+The repository provides `.env.example` as a template. Copy it and fill in values:
+
+```bash
+cp .env.example .env
+```
+
+To see exactly which variables are expected, read the template — it is the single
+source of truth:
+
+```bash
+cat .env.example
+```
+
+`.env` is intended to stay on your machine; check `.gitignore` before committing
+anything that looks like a secret.
+
+> **TODO (maintainer):** state whether `.env` is *required* for a plain local
+> build, or only for optional integrations, and which variables are mandatory.
+
+---
+
+## 4. Run the site
+
+### Option A — Docker Compose
+
+`docker-compose.yml` lives at the repository root. First, see what it defines:
+
+```bash
+docker compose config --services   # list the service names
+docker compose config              # the fully-resolved configuration, incl. ports
+```
+
+Then start everything in the foreground (Ctrl-C to stop):
+
+```bash
+docker compose up
+```
+
+Or in the background, with logs followed separately:
+
+```bash
+docker compose up -d
+docker compose logs -f
+docker compose down          # stop and remove the containers
+```
+
+Open the port published by the service — read it from the `ports:` mapping shown
+by `docker compose config`.
+
+> **TODO (maintainer):** replace the above with the concrete service name and
+> URL, e.g. `docker compose up <service>` → <http://localhost:PORT>.
+
+### Option B — Native Ruby / Bundler
+
+The root `Gemfile` declares the Ruby dependencies:
+
+```bash
+bundle install
+```
+
+Then run the Jekyll development server:
+
+```bash
+bundle exec jekyll serve
+```
+
+By default Jekyll reads `_config.yml`. This repository *also* contains
+`_config_dev.yml`, which suggests a development override is layered on top —
+Jekyll supports this with a comma-separated list:
+
+```bash
+bundle exec jekyll serve --config _config.yml,_config_dev.yml
+```
+
+> **TODO (maintainer):** confirm which invocation is correct here — whether
+> `_config_dev.yml` is layered as above, whether `docker-compose.yml` already
+> applies it, and what the local URL/port is.
+
+---
+
+## 5. Build and automation tasks
+
+A `Rakefile` sits at the repository root. Rather than memorising task names, ask
+Rake what it offers:
+
+```bash
+bundle exec rake -T          # list all documented tasks with descriptions
+bundle exec rake -T build    # filter to tasks matching "build"
+```
+
+Run a task with:
+
+```bash
+bundle exec rake <task_name>
+```
+
+> **TODO (maintainer):** call out the two or three tasks a newcomer actually
+> needs (build, test, lint, deploy) so they don't have to guess from `rake -T`.
+
+### Pre-commit hooks
+
+If you have `pre-commit` installed, wire up the hooks declared in
+`.pre-commit-config.yaml`:
+
+```bash
+pre-commit install
+pre-commit run --all-files   # run every hook across the repo once
+```
+
+---
+
+## 6. Repository layout
+
+The top level of the monorepo:
+
+| Path | What it is |
+| --- | --- |
+| `_config.yml`, `_config_dev.yml` | Jekyll site configuration (production and development) |
+| `_data/` | Jekyll data files |
+| `_reports/` | Generated or checked-in reports |
+| `assets/` | Static assets for the site |
+| `docs/` | Documentation (you are here) |
+| `index.md`, `pages/` | Site content |
+| `projects/` | Project directories (several are git submodules — see `.gitmodules`) |
+| `templates/` | Reusable templates |
+| `tools/` | Repository tooling and scripts |
+| `Gemfile` | Ruby dependencies |
+| `Rakefile` | Automation tasks |
+| `docker-compose.yml` | Container definition for local development |
+| `fleet.manifest.yml` | Fleet/automation manifest |
+| `home.code-workspace` | VS Code multi-root workspace file |
+| `.devcontainer/` | VS Code Dev Container definition |
+| `.github/` | GitHub workflows, issue and PR templates |
+| `.vscode/` | Editor settings shared with the team |
+| `.claude/`, `.mcp.json` | AI agent configuration |
+
+Shell dotfiles (`.zshrc`, `.zprofile`, `.gitconfig`) are tracked at the root —
+this repository doubles as a dotfiles/home directory. Read them before running
+anything that might symlink them over your own configuration.
+
+---
+
+## 7. Related documentation
+
+| Document | Purpose |
+| --- | --- |
+| [`CONTRIBUTING.md`](../CONTRIBUTING.md) | Contribution workflow, branch and commit conventions |
+| [`SUBMODULES.md`](../SUBMODULES.md) | Working with the git submodules in `projects/` |
+| [`SCHEMA.md`](../SCHEMA.md) | Data/content schema reference |
+| [`AGENTS.md`](../AGENTS.md), [`CLAUDE.md`](../CLAUDE.md) | Conventions for AI agents operating on this repository |
+| [`fleet.manifest.yml`](../fleet.manifest.yml) | Automation manifest |
+
+---
+
+## 8. Troubleshooting
+
+**Empty directories under `projects/`** — submodules were not initialised. Run
+`git submodule update --init --recursive`.
+
+**`bundler: command not found: jekyll`** — dependencies are not installed for the
+current Ruby. Re-run `bundle install`, and make sure you are prefixing commands
+with `bundle exec`.
+
+**Port already in use with Docker** — something else is bound to the published
+port. Check with `docker compose ps` and `docker compose config`, then stop the
+conflicting process or change the mapping.
+
+**Changes not appearing in the browser** — Jekyll's watcher can miss files inside
+bind-mounted volumes on some platforms. Restart the server, or check whether the
+path is excluded in `_config.yml`.
+
+---
+
+*Found a gap or an inaccuracy in this guide? Please open a PR — the `TODO
+(maintainer)` callouts above are the known unknowns and are the best place to
+start.*


### PR DESCRIPTION
## What this adds

A new `docs/local-development.md` that gives a newcomer a path from `git clone` to a running local site, plus a map of the top-level repository layout.

The repository root contains `docker-compose.yml`, `Gemfile`, `Rakefile`, `_config.yml`, `_config_dev.yml`, `.env.example`, `.gitmodules` and `.devcontainer/`, but `README.md` is a personal-profile README with no setup instructions for the monorepo itself. This PR fills that gap without touching the profile README.

## How I kept it accurate

I was working from a repository **file listing** only — I did not have the contents of `docker-compose.yml`, `Gemfile`, `Rakefile`, `SUBMODULES.md` or `CONTRIBUTING.md`. So the guide deliberately avoids naming things I cannot see (compose service names, Rake task names, Jekyll flags, required env vars). Instead it teaches *discovery* commands that are true regardless of file contents:

- `docker compose config --services` instead of guessing a service name
- `bundle exec rake -T` instead of guessing task names
- `cat .env.example` instead of listing variables
- `git submodule update --init --recursive` (generic git, justified by the presence of `.gitmodules`)

Every place a maintainer needs to fill in a specific value is marked with a `> **TODO (maintainer):**` callout so the gaps are obvious and greppable.

## ⚠️ Please verify before merging

These are the things I could **not** confirm from the evidence available to me:

1. **Compose service name and exposed port.** The guide says "see `docker compose config --services`" and "the port published in `docker-compose.yml`" rather than asserting `4000`. Please substitute the real values.
2. **How `_config_dev.yml` is meant to be used.** Both `_config.yml` and `_config_dev.yml` exist; I do not know whether they are layered (`--config _config.yml,_config_dev.yml`), whether `docker-compose.yml` already wires this up, or whether a Rake task does. The guide asks the maintainer to state this.
3. **Rake tasks.** `Rakefile` exists but I have not seen it — no task names are claimed anywhere in the doc.
4. **Whether `.env` is actually required** for a plain local build, and which variables in `.env.example` are mandatory vs optional.
5. **Node tooling.** `.husky/`, `.prettierrc` and `.prettierignore` are present at the root but I did not see a `package.json` in the top-level listing. I therefore did **not** document `npm install` / `npx husky install`. If Node tooling is expected, please add it (and if the missing `package.json` is a bug, that is worth a separate issue).
6. **`SUBMODULES.md` / `CONTRIBUTING.md` contents.** The guide links to them as the authoritative sources rather than summarising them.
7. **Whether `docs/` is itself published by Jekyll**, and therefore whether the YAML front matter I added to the new file is appropriate. I added `title`/`description` front matter to match the style of `README.md`; remove it if `docs/` is excluded from the build.

Drafted as a PR for review — happy to tighten it once someone pastes the real service name and Rake task list.

---
🤖 wtd fleet · `doc-writer` agent · item `bamr87/bamr87:write_docs:2747feae85b7`
<!-- wtd-fleet:bamr87/bamr87:write_docs:2747feae85b7 -->