### PR TITLE
fix(ci): stop asking to mint an optional credential nobody wants

### DIFF
--- a/tools/fleet-config.py
+++ b/tools/fleet-config.py
@@ -700,12 +700,25 @@ def hub_row(rows: list[dict], hub_nwo: str) -> dict | None:
     return next((r for r in rows if r["nwo"] == hub_nwo), None)
 
 
-def needs_human_mint(rows: list[dict], pol: dict, hub_nwo: str) -> bool:
-    """True when the credential itself is approaching the end of its life.
+def needs_human_mint(rows: list[dict], pol: dict, hub_nwo: str,
+                     required: bool = True) -> bool:
+    """True when a human has to go mint a credential.
 
     The hub's `updated_at` is the best available proxy for when the credential
     was minted — nothing else in the system records it, and the secrets API
     offers no expiry field.
+
+    Two conditions reach this answer, and they are not the same question:
+
+      aging    the hub HOLDS a credential and it is nearing the end of its
+               one-year life. Worth flagging whatever the contract says, since
+               an expired credential breaks every repo holding a copy.
+      absent   the hub holds NO credential. Worth flagging only when the
+               contract marks the secret required. ANTHROPIC_API_KEY is the
+               fallback nobody has provisioned, and its absence is the intended
+               state — asking for it every week is how a weekly report gets
+               skimmed and then ignored. Same reasoning as the `needs-seed`
+               guard in cmd_rotate, which this mirrors.
     """
     lifetime = int(pol.get("lifetime_days") or 0)
     renew_before = int(pol.get("renew_before_days") or 0)
@@ -713,7 +726,7 @@ def needs_human_mint(rows: list[dict], pol: dict, hub_nwo: str) -> bool:
         return False
     row = hub_row(rows, hub_nwo)
     if row is None or row["age_days"] is None:
-        return row is not None and row["state"] == S_MISSING
+        return required and row is not None and row["state"] == S_MISSING
     return row["age_days"] >= max(0, lifetime - renew_before)
 
 
@@ -922,7 +935,8 @@ def cmd_rotation_plan(args: argparse.Namespace) -> int:
         repos = rotation_targets(cfg, registry, t, args.repo)
         rows = survey(t, repos, cache, hub_nwo)
         attention = []
-        if needs_human_mint(rows, t["_rotation"], hub_nwo):
+        if needs_human_mint(rows, t["_rotation"], hub_nwo,
+                            bool(t.get("required"))):
             attention.append("needs-mint")
         if any(r["state"] in (S_STALE, S_MISSING) for r in rows):
             attention.append("needs-propagate")
@@ -996,7 +1010,8 @@ def cmd_rotate(args: argparse.Namespace) -> int:
         minted_any = minted_any or minted
 
         attention = []
-        if needs_human_mint(rows, pol, hub_nwo) and not minted:
+        if needs_human_mint(rows, pol, hub_nwo,
+                            bool(t.get("required"))) and not minted:
             attention.append("needs-mint")
         # Only a REQUIRED secret missing its value is worth anyone's attention.
         # ANTHROPIC_API_KEY is the fallback nobody has provisioned; flagging its


### PR DESCRIPTION
## Description

The first **apply** run of the rotation loop ([run #4](https://github.com/bamr87/bamr87/actions/runs/32785811072)) wrote 31 repos cleanly with 0 failures — and then filed this, against a secret that is working exactly as designed:

```
ANTHROPIC_API_KEY   attention: ['needs-mint']
```

`ANTHROPIC_API_KEY` is the fallback credential: `required: false` in the token contract, and deliberately unprovisioned. The hub holds no copy and nobody wants it to. Asking a human to go mint one every Monday is how a weekly report gets skimmed once and ignored after that.

The guard already existed one line away. `needs-seed` is raised only for a **required** secret, with a comment saying why. `needs-mint` reached the same "the hub has nothing" conclusion through `needs_human_mint()` and had no such guard — so the two signals disagreed about the same fact.

`needs_human_mint()` now takes `required` (defaulting to `True`, so no call site changes behaviour silently) and applies it to the **absent** branch only. The two conditions were never the same question:

| condition | meaning | flagged? |
| --- | --- | --- |
| **aging** | the hub *holds* a credential nearing the end of its one-year life | always — an expired credential breaks every repo holding a copy, optional or not |
| **absent** | the hub holds *no* credential | only when the contract marks it required; otherwise absence is the intended state |

## Related Issues

Surfaced by the apply run dispatched after #155 merged. Affects the body of the recurring rotation issue #148.

## Type Of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Maintenance or refactor
- [x] Test improvement

## Verification

- [x] Tests pass — a new `test_needs_mint.py` (12 checks) replaying the real 22:41 UTC run: optional+absent is now quiet, required+absent still asks, **optional+aging still asks** (the half that must not regress), a fresh hub copy stays quiet, the default argument preserves the old behaviour, and end-to-end a rotate run raises empty attention for the optional key while still raising both `needs-mint` and `needs-seed` for the required one. The other four rotation suites (`test_rotation.py`, `test_extra.py`, `test_variables.py`, `test_behind_hub.py`) all still pass.
- [x] Lint/type checks pass — `python3 tools/schema_lint.py check .` 0 errors / 0 warnings, `tools/check-drift.sh` clean, `python3 -m py_compile tools/fleet-config.py` clean. One Python file changed; no shell script, workflow, or action manifest, so `shellcheck`/`actionlint` have nothing to say about it.
- [x] Manual verification completed — the false alarm is reproduced from the published ledger, not hypothesised.

Also asserted, after the near-miss on #155: the five suites leave `_data/token_rotation.yml` byte-identical. A stubbed harness must never write the fleet's real audit record.

## Notes For Reviewers

- **Scope is one branch of one predicate.** The aging signal is untouched, and `required=True` is the default, so every existing caller behaves exactly as before unless it opts in.
- The apply run this came from is the real validation of the whole loop: 31 written, 0 failed, hub not rewritten, 2 unreachable repos skipped rather than failed, and the `behind_hub` rule from #155 correctly catching 6 repos — the 3 that were only-behind plus 3 that were aged-out-and-behind.
- `ANTHROPIC_API_KEY` stays unprovisioned. This PR makes the loop stop asking for it; it does not decide whether the fleet should have one.

---
_Generated by [Claude Code](https://claude.ai/code/session_012ywDA51XQTvRC8T74hQqWJ)_