### PR TITLE
fix(ci): fleet-pulse doctor — name the rejected Claude credential instead of a bare is_error

### DIFF
--- a/.github/workflows/fleet-pulse.yml
+++ b/.github/workflows/fleet-pulse.yml
@@ -373,6 +373,46 @@ jobs:
               workflow look green. Fix the cause or file an issue.
             - Be specific and technical. No boilerplate.
 
+      # `claude-code-action` surfaces a rejected credential as a bare
+      # `is_error: true` with NO message, so the annotation reads "Claude
+      # execution failed" and names nothing. That is how an expired
+      # CLAUDE_CODE_OAUTH_TOKEN kept this job red from 2026-08-17 to 08-24
+      # without anyone being told which secret to rotate. The result record
+      # does carry the tell: a credential rejected at the first API call
+      # bills nothing, so `total_cost_usd == 0` AND an empty `modelUsage`
+      # means the model was never actually reached — as opposed to a genuine
+      # agent failure, which always has usage against it. Classify it here so
+      # the next expiry costs one run instead of eight days.
+      - name: Diagnose Claude failure
+        if: ${{ failure() && env.HAS_CLAUDE_AUTH == 'true' }}
+        run: |
+          log="${RUNNER_TEMP}/claude-execution-output.json"
+          if [ ! -f "$log" ]; then
+            echo "::warning::Claude failed before writing an execution log — check the step output directly."
+            exit 0
+          fi
+          result=$(jq -c '[.. | objects | select(.type? == "result")] | last // empty' "$log" 2>/dev/null || true)
+          if [ -z "$result" ]; then
+            echo "::warning::No result record in the Claude execution log — check the step output directly."
+            exit 0
+          fi
+          cost=$(printf '%s' "$result" | jq -r '.total_cost_usd // 0')
+          models=$(printf '%s' "$result" | jq -r '(.modelUsage // {}) | length')
+          turns=$(printf '%s' "$result" | jq -r '.num_turns // 0')
+          if [ "$models" = "0" ] && [ "$cost" = "0" ]; then
+            echo "::error::Claude was never reached: 0 billed turns, empty modelUsage. The Claude credential was REJECTED (expired or revoked), not rate-limited. Rotate CLAUDE_CODE_OAUTH_TOKEN — see docs/TOKEN-ROTATION.md."
+            {
+              echo "### 🩺 Fleet doctor — Claude credential rejected"
+              echo ""
+              echo "The agent made **no billed API call** (\`total_cost_usd: 0\`, \`modelUsage: {}\`, \`num_turns: $turns\`)."
+              echo "The secret is present — \`HAS_CLAUDE_AUTH\` only tests that — but the API refused it."
+              echo ""
+              echo "**Fix:** rotate \`CLAUDE_CODE_OAUTH_TOKEN\` in this repo, then run \`token-rotation.yml\` to propagate it to the fleet."
+            } >> "$GITHUB_STEP_SUMMARY"
+          else
+            echo "::warning::Claude ran ($turns turn(s), \$$cost billed) and still failed — this is an agent/tooling failure, not an auth failure."
+          fi
+
       - name: Summary
         if: always()
         run: |


### PR DESCRIPTION
<!-- fleet-doctor key="bamr87/bamr87:.github/workflows/fleet-pulse.yml" -->

## Problem

`bamr87/bamr87` · `.github/workflows/fleet-pulse.yml` · signals: `failing`

The `doctor` job has failed on **every scheduled run from 2026-08-17 through 2026-08-24** — eight consecutive days. Last green run was 2026-08-16. The queued failure is [run 32696970893](https://github.com/bamr87/bamr87/actions/runs/32696970893) (2026-08-24 06:21 UTC), but it is one of a solid streak, not an isolated event.

The `pulse` job was healthy throughout (14m41s, green). Only `doctor` — the Claude Code step — died, in 32 seconds.

Every failing run carries exactly three annotations and nothing else:

```
Claude result reported subtype success with is_error:true (run did not complete successfully)
Action failed with error: Claude execution failed: result is_error:true
Process completed with exit code 1.
```

That names no cause, which is why this ran red for eight days without anyone being able to act on it. Hub issue #116 was filed on 2026-08-20 against this same workflow and — having no job logs — guessed at unresolvable `actions/checkout@v7` tags. That hypothesis is wrong; setup completed fine in every run.

## Root cause

The credential was rejected at the first API call. The result record in the run log is the tell:

```json
{
  "type": "result", "subtype": "success", "is_error": true,
  "duration_ms": 1990, "num_turns": 1,
  "total_cost_usd": 0, "modelUsage": {}
}
```

`Claude Code initialized` at 06:36:35.9, error at 06:36:37.9 — **two seconds**, one turn, **nothing billed and an empty `modelUsage`**. The model was never actually reached. A genuine agent or tooling failure always has usage recorded against it; only a refused credential bills zero.

Corroboration that this was `CLAUDE_CODE_OAUTH_TOKEN` and not, say, a rate limit:

- `gh api repos/bamr87/bamr87/actions/secrets` shows `CLAUDE_CODE_OAUTH_TOKEN` `updated_at = 2026-08-24T22:26:50Z` — **after** the last failing run, and the 2026-08-25 run is green.
- The identical 2-second / zero-usage signature appears fleet-wide in the same window: `bamr87/gitorio` `Factory: Gitorio Factory 2` failed 08-17→08-24 and went green 08-25; `bamr87/lifehacker.dev` recovered the same night. All three consume the same propagated hub credential.
- `bamr87/zer0-mistakes#418` — *"AI content review posts an auth failure on PRs: 401 OAuth access token has been revoked"* — is the same incident seen from a repo that happened to surface the HTTP status.

The workflow-level defect that turned a credential expiry into an eight-day outage is on line 220:

```yaml
HAS_CLAUDE_AUTH: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN != '' || secrets.ANTHROPIC_API_KEY != '' }}
```

That tests only that the secret is **non-empty**. A dead credential passes it, the job proceeds, and the action reports an unreadable `is_error: true`. This is precisely the trap the adjacent `Probe fleet write token` step (line 247) already exists to catch for `FLEET_TOKEN`, whose own comment reads *"A secret can be SET and still be dead."* The Claude credential never got the same treatment — and it is the one whose failure disables the loop that would otherwise have diagnosed it.

## Fix

Adds one step, `Diagnose Claude failure`, gated on `failure() && HAS_CLAUDE_AUTH == 'true'`. It reads the execution log the action already writes to `$RUNNER_TEMP/claude-execution-output.json` and classifies the result:

- **zero billed turns + empty `modelUsage`** → `::error::` naming `CLAUDE_CODE_OAUTH_TOKEN` as rejected, with a step-summary block pointing at `docs/TOKEN-ROTATION.md`.
- **anything else** → `::warning::` saying the agent ran and failed on its own merits, so nobody wastes a rotation on a real bug.

Deliberately **not** a pre-flight probe: there is no cheap, reliable liveness check for an OAuth credential equivalent to `gh api user`, and a probe that guessed wrong would either gate a healthy job off or cry wolf daily. Post-hoc classification uses evidence the action already produces and cannot be wrong in the direction that costs anything.

The step is purely additive and `failure()`-gated — a healthy run never executes it. It does not retry, does not set `continue-on-error`, and does not make a red run look green: the job still fails, it just says why.

Verified the `jq` extraction against both real result shapes (the streamed array and a bare result object) and against the two branches (`cost=0 models=0` → auth; non-zero usage → agent failure).

## Expected impact

No minutes recovered directly — this is a diagnosis fix, not a cost fix. The value is bounded by what the last outage cost: **8 daily doctor runs plus a full fleet-wide agent outage**, un-actioned because the failure named nothing. Next expiry should cost one run.

## Links

- Failing run: https://github.com/bamr87/bamr87/actions/runs/32696970893
- Green run after rotation: https://github.com/bamr87/bamr87/actions/runs/32816188641
- Related, should probably be closed by this: bamr87/bamr87#116 (same workflow, hypotheses formed without logs)
- Dash: https://bamr87.github.io/bamr87/actions/
