### PR TITLE
fix(ci): issue-pipeline — name the rejected Claude credential in all three tiers

### DIFF
--- a/.github/workflows/issue-pipeline.yml
+++ b/.github/workflows/issue-pipeline.yml
@@ -460,6 +460,47 @@ jobs:
               a comment, you have already done this one — skip it.
             - Redact anything credential-shaped before quoting a log.
 
+      # `claude-code-action` surfaces a rejected credential as a bare
+      # `is_error: true` with NO message, so the annotation reads "Claude
+      # execution failed" and names nothing. That is how an expired
+      # CLAUDE_CODE_OAUTH_TOKEN kept tiers 1 and 3 red from 2026-08-15 to
+      # 08-24 without anyone being told which secret to rotate. The result
+      # record does carry the tell: a credential rejected at the first API
+      # call bills nothing, so `total_cost_usd == 0` AND an empty
+      # `modelUsage` means the model was never reached — as opposed to a
+      # genuine agent failure, which always has usage against it.
+      # HAS_CLAUDE_AUTH only tests that the secret is non-empty, exactly the
+      # present-but-expired trap `Probe fleet write token` catches for
+      # FLEET_TOKEN. Classify it so the next expiry costs one run, not ten days.
+      - name: Diagnose Claude failure
+        if: ${{ failure() && env.HAS_CLAUDE_AUTH == 'true' }}
+        env:
+          TIER: Tier 1 — intake
+        run: |
+          log="${RUNNER_TEMP}/claude-execution-output.json"
+          result=""
+          [ -f "$log" ] && result=$(jq -c '[.. | objects | select(.type? == "result")] | last // empty' "$log" 2>/dev/null || true)
+          if [ -z "$result" ]; then
+            echo "::warning::${TIER}: Claude produced no result record — check the step output directly."
+            exit 0
+          fi
+          cost=$(printf '%s' "$result" | jq -r '.total_cost_usd // 0')
+          models=$(printf '%s' "$result" | jq -r '(.modelUsage // {}) | length')
+          turns=$(printf '%s' "$result" | jq -r '.num_turns // 0')
+          if [ "$models" = "0" ] && [ "$cost" = "0" ]; then
+            echo "::error::${TIER}: Claude was never reached — 0 billed turns, empty modelUsage. The Claude credential was REJECTED (expired or revoked), not rate-limited. Rotate CLAUDE_CODE_OAUTH_TOKEN — see docs/TOKEN-ROTATION.md."
+            {
+              echo "### 🧭 ${TIER} — Claude credential rejected"
+              echo ""
+              echo "No billed API call (\`total_cost_usd: 0\`, \`modelUsage: {}\`, \`num_turns: $turns\`)."
+              echo "The secret is present — \`HAS_CLAUDE_AUTH\` only tests that — but the API refused it."
+              echo ""
+              echo "**Fix:** rotate \`CLAUDE_CODE_OAUTH_TOKEN\`, then run \`token-rotation.yml\` to propagate it."
+            } >> "$GITHUB_STEP_SUMMARY"
+          else
+            echo "::warning::${TIER}: Claude ran ($turns turn(s), \$$cost billed) and still failed — an agent/tooling failure, not auth."
+          fi
+
       - name: Summary
         if: always()
         run: |
@@ -641,6 +682,38 @@ jobs:
             - `assisted` issues get the same full implementation — the
               difference is that tier 3 will leave the PR as a draft for a human.
 
+      # See the tier-1 copy of this step for why a bare `is_error: true` needs
+      # classifying: zero billed turns + empty modelUsage means the credential
+      # was refused, anything else means the agent itself failed.
+      - name: Diagnose Claude failure
+        if: ${{ failure() && env.HAS_CLAUDE_AUTH == 'true' }}
+        env:
+          TIER: Tier 2 — implement
+        run: |
+          log="${RUNNER_TEMP}/claude-execution-output.json"
+          result=""
+          [ -f "$log" ] && result=$(jq -c '[.. | objects | select(.type? == "result")] | last // empty' "$log" 2>/dev/null || true)
+          if [ -z "$result" ]; then
+            echo "::warning::${TIER}: Claude produced no result record — check the step output directly."
+            exit 0
+          fi
+          cost=$(printf '%s' "$result" | jq -r '.total_cost_usd // 0')
+          models=$(printf '%s' "$result" | jq -r '(.modelUsage // {}) | length')
+          turns=$(printf '%s' "$result" | jq -r '.num_turns // 0')
+          if [ "$models" = "0" ] && [ "$cost" = "0" ]; then
+            echo "::error::${TIER}: Claude was never reached — 0 billed turns, empty modelUsage. The Claude credential was REJECTED (expired or revoked), not rate-limited. Rotate CLAUDE_CODE_OAUTH_TOKEN — see docs/TOKEN-ROTATION.md."
+            {
+              echo "### 🧭 ${TIER} — Claude credential rejected"
+              echo ""
+              echo "No billed API call (\`total_cost_usd: 0\`, \`modelUsage: {}\`, \`num_turns: $turns\`)."
+              echo "The secret is present — \`HAS_CLAUDE_AUTH\` only tests that — but the API refused it."
+              echo ""
+              echo "**Fix:** rotate \`CLAUDE_CODE_OAUTH_TOKEN\`, then run \`token-rotation.yml\` to propagate it."
+            } >> "$GITHUB_STEP_SUMMARY"
+          else
+            echo "::warning::${TIER}: Claude ran ($turns turn(s), \$$cost billed) and still failed — an agent/tooling failure, not auth."
+          fi
+
       - name: Summary
         if: always()
         run: |
@@ -773,6 +846,38 @@ jobs:
             - Never modify anything under `projects/` in this checkout.
             - Do not open new PRs — you finish existing ones.
             - Be specific in every comment. Quote the failing line, name the fix.
+
+      # See the tier-1 copy of this step for why a bare `is_error: true` needs
+      # classifying: zero billed turns + empty modelUsage means the credential
+      # was refused, anything else means the agent itself failed.
+      - name: Diagnose Claude failure
+        if: ${{ failure() && env.HAS_CLAUDE_AUTH == 'true' }}
+        env:
+          TIER: Tier 3 — complete
+        run: |
+          log="${RUNNER_TEMP}/claude-execution-output.json"
+          result=""
+          [ -f "$log" ] && result=$(jq -c '[.. | objects | select(.type? == "result")] | last // empty' "$log" 2>/dev/null || true)
+          if [ -z "$result" ]; then
+            echo "::warning::${TIER}: Claude produced no result record — check the step output directly."
+            exit 0
+          fi
+          cost=$(printf '%s' "$result" | jq -r '.total_cost_usd // 0')
+          models=$(printf '%s' "$result" | jq -r '(.modelUsage // {}) | length')
+          turns=$(printf '%s' "$result" | jq -r '.num_turns // 0')
+          if [ "$models" = "0" ] && [ "$cost" = "0" ]; then
+            echo "::error::${TIER}: Claude was never reached — 0 billed turns, empty modelUsage. The Claude credential was REJECTED (expired or revoked), not rate-limited. Rotate CLAUDE_CODE_OAUTH_TOKEN — see docs/TOKEN-ROTATION.md."
+            {
+              echo "### 🧭 ${TIER} — Claude credential rejected"
+              echo ""
+              echo "No billed API call (\`total_cost_usd: 0\`, \`modelUsage: {}\`, \`num_turns: $turns\`)."
+              echo "The secret is present — \`HAS_CLAUDE_AUTH\` only tests that — but the API refused it."
+              echo ""
+              echo "**Fix:** rotate \`CLAUDE_CODE_OAUTH_TOKEN\`, then run \`token-rotation.yml\` to propagate it."
+            } >> "$GITHUB_STEP_SUMMARY"
+          else
+            echo "::warning::${TIER}: Claude ran ($turns turn(s), \$$cost billed) and still failed — an agent/tooling failure, not auth."
+          fi
 
       - name: Summary
         if: always()


### PR DESCRIPTION
<!-- fleet-doctor key="bamr87/bamr87:.github/workflows/issue-pipeline.yml" -->

## Problem

`bamr87/bamr87` · `.github/workflows/issue-pipeline.yml` · signals: `failing`

The pipeline has failed on **every scheduled run from 2026-08-15 through 2026-08-24** — ten consecutive days, with a single green outlier on 08-14. The queued failure is [run 32705647272](https://github.com/bamr87/bamr87/actions/runs/32705647272) (2026-08-24 08:18 UTC).

The deterministic half was healthy the whole time. In the queued run:

| Job | Result |
| --- | --- |
| `scan` — issues & tier queues | ✅ 1m23s |
| `tier1` — intake & evidence | ❌ 54s |
| `tier2` — implement | ✅ 1m12s (Claude step skipped — `has_implement` false) |
| `tier3` — complete | ❌ 28s |

`Build evidence bundles` and `Upload evidence bundles` both succeeded. Only the `claude-code-action` steps died, and they died in seconds.

Both failing tiers carry the same three annotations and nothing else:

```
Claude result reported subtype success with is_error:true (run did not complete successfully)
Action failed with error: Claude execution failed: result is_error:true
Process completed with exit code 1.
```

## Root cause

The credential was rejected at the first API call. Both tiers' result records show it:

```json
// tier 1                                    // tier 3
{ "type": "result",                          { "type": "result",
  "is_error": true,                            "is_error": true,
  "duration_ms": 2049, "num_turns": 1,         "duration_ms": 1976, "num_turns": 1,
  "total_cost_usd": 0, "modelUsage": {} }      "total_cost_usd": 0, "modelUsage": {} }
```

Tier 1: `Claude Code initialized` 08:20:56.6 → error 08:20:58.7. **Two seconds, one turn, nothing billed, empty `modelUsage`.** The model was never reached. A genuine agent or tooling failure always has usage recorded against it; only a refused credential bills zero.

Corroboration that this was `CLAUDE_CODE_OAUTH_TOKEN`:

- `gh api repos/bamr87/bamr87/actions/secrets` shows `CLAUDE_CODE_OAUTH_TOKEN` `updated_at = 2026-08-24T22:26:50Z` — **after** the last failing run.
- The identical signature appears fleet-wide in the same window (`fleet-pulse` doctor 08-17→08-24, `bamr87/gitorio` 08-17→08-24, `bamr87/lifehacker.dev`), all consuming the same propagated hub credential, and all green again on 08-25.
- `bamr87/zer0-mistakes#418` — *"401 OAuth access token has been revoked"* — is the same incident from a repo that surfaced the HTTP status.

The workflow-level defect that let a credential expiry run silently for ten days appears at lines 228, 491 and 673:

```yaml
HAS_CLAUDE_AUTH: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN != '' || secrets.ANTHROPIC_API_KEY != '' }}
```

That tests only that the secret is **non-empty**. A dead credential passes it, the tier proceeds, and the action reports an unreadable `is_error: true`. This workflow already knows better for the *other* credential — the `Probe fleet write token` step (line 515) exists precisely because *"A secret can be SET and still be dead"*, and the file's own header comment at line 47 says `FLEET_TOKEN` is *"Probed for real, not just presence-"* checked. The Claude credential never got that treatment.

## Fix

Adds a `Diagnose Claude failure` step to **all three tiers**, gated on `failure() && HAS_CLAUDE_AUTH == 'true'`. It reads the execution log the action already writes to `$RUNNER_TEMP/claude-execution-output.json` and classifies:

- **zero billed turns + empty `modelUsage`** → `::error::` naming `CLAUDE_CODE_OAUTH_TOKEN` as rejected, plus a step-summary block pointing at `docs/TOKEN-ROTATION.md`.
- **anything else** → `::warning::` saying the agent ran and failed on its own merits, so nobody burns a rotation on a real bug.

Applied to tier 2 as well even though it passed in the queued run: it passed only because `has_implement` was false and its Claude step was skipped. It carries the identical latent defect, and a fix that left it out would just relocate the next silent outage.

Deliberately **not** a pre-flight probe. There is no cheap, reliable liveness check for an OAuth credential equivalent to `gh api user`, and a probe that guessed wrong would either gate healthy tiers off or cry wolf daily. Post-hoc classification uses evidence the action already emits and cannot be wrong in the direction that costs anything.

Purely additive and `failure()`-gated — a healthy run never executes it. No retries, no `continue-on-error`, no red run made to look green: the tier still fails, it just says why.

Verified the `jq` extraction against both real result shapes (streamed array and bare result object) and both branches (`cost=0 models=0` → auth; non-zero usage → agent failure). Workflow syntax is validated by this repo's own `drift-check` actionlint sweep on this PR.

## Expected impact

No minutes recovered directly — this is a diagnosis fix, not a cost fix. Bounded by what the last outage cost: **10 days of intake, implementation and completion not happening**, with nothing in the logs naming the secret to rotate. Next expiry should cost one run.

## Links

- Failing run: https://github.com/bamr87/bamr87/actions/runs/32705647272
- Companion PR for the same root cause in the doctor loop: #160
- Dash: https://bamr87.github.io/bamr87/actions/
