### PR TITLE
fix(fanout): honour a repo's own gate excludes when seeding the prose kit

### DIFF
--- a/tools/fanout.sh
+++ b/tools/fanout.sh
@@ -262,9 +262,21 @@ seed_prose() {
   seed_workflow_artifact "markdown-oneline.yml" .github/workflows/markdown-oneline.yml \
     "$HUB/templates/prose/markdown-oneline.yml" "$name" "$def" "$PROSE_VERSION"
   # 3. one-time fix: unwrap wrapped prose in every tracked markdown file, leaving
-  #    lint-gated SCHEMA.md contracts and release-please CHANGELOGs untouched
-  python3 tools/unwrap-prose.py --write \
-    --exclude '(^|/)SCHEMA\.md$' --exclude '(^|/)CHANGELOG\.md$' >/dev/null 2>&1 || true
+  #    lint-gated SCHEMA.md contracts and release-please CHANGELOGs untouched.
+  #    Honour the repo's OWN gate excludes when it declares any: seeding with the
+  #    defaults rewrote 24 machine-authored quest reports in it-journey, which
+  #    exempts exactly those paths — a PR its own gate would never have asked for,
+  #    against files the quest loop regenerates wrapped anyway.
+  local ex pat
+  ex=(--exclude '(^|/)SCHEMA\.md$' --exclude '(^|/)CHANGELOG\.md$')
+  if [[ -f .github/workflows/markdown-oneline.yml ]] \
+     && grep -q -- "--exclude '" .github/workflows/markdown-oneline.yml; then
+    ex=()
+    while IFS= read -r pat; do ex+=(--exclude "$pat"); done \
+      < <(grep -o -- "--exclude '[^']*'" .github/workflows/markdown-oneline.yml \
+          | sed "s/^--exclude '//; s/'$//")
+  fi
+  python3 tools/unwrap-prose.py --write "${ex[@]}" >/dev/null 2>&1 || true
 }
 
 run_one() {


### PR DESCRIPTION
## The bug

`seed_prose()` hardcoded the default excludes:

```bash
python3 tools/unwrap-prose.py --write \
  --exclude '(^|/)SCHEMA\.md$' --exclude '(^|/)CHANGELOG\.md$'
```

So a repo that declares its **own** excludes got unwrapped against a rule it had deliberately opted out of.

Caught live during the fleet-wide prose fan-out: it-journey exempts `pages/_quest-reports/` and `test/quest-validator/walkthroughs/` (the quest-perfection loop authors those and regenerates them soft-wrapped). The fan-out rewrote **24 of exactly those files** into a PR its own gate would never have asked for — closed as bamr87/it-journey#653.

## The fix

The seed now parses the `--exclude` patterns out of the repo's existing `markdown-oneline.yml` and falls back to the defaults when it declares none — the same approach `tools/install-prose-hook.sh` already uses for the local hook.

## Verification

Run against it-journey's real workflow, the parsed excludes are the full custom set, and the seed step becomes a no-op:

```
--exclude (^|/)SCHEMA\.md$
--exclude (^|/)CHANGELOG\.md$
--exclude (^|/)pages/_quest-reports/
--exclude (^|/)test/quest-validator/walkthroughs/
$ python3 tools/unwrap-prose.py --check "${ex[@]}"
All markdown prose already unwrapped.
```

`shellcheck --severity=warning` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)