### PR TITLE
docs: add contributor-facing development map (docs/development.md)

### DIFF
--- a/docs/development.md
+++ b/docs/development.md
@@ -1,0 +1,152 @@
+---
+title: Development Guide
+description: Contributor-facing entry point for the bamr87/bamr87 monorepo.
+---
+
+# Development Guide
+
+> **Draft.** This page was assembled from the repository's file listing. Sections
+> marked **TODO** need a maintainer to fill in exact commands from the config
+> files they reference. Nothing here is guessed: where a command was not
+> verifiable, it is left blank rather than invented.
+
+## Start here (and not in the root README)
+
+The `README.md` at the root of this repository is a **GitHub profile README**.
+Its front matter reads `title: Amr Abdel-Motaleb - Solutions Architect & ERP
+Specialist`, and its audience is people visiting the `bamr87` GitHub profile —
+not people cloning the repository.
+
+This page is the counterpart: the entry point for anyone who wants to run,
+build, or change the code.
+
+## Repository map
+
+The repository is described in its own metadata as a **monorepo**, primary
+language **Shell**, default branch **`main`**. Here is what lives at the top
+level.
+
+### Documentation
+
+| Path | What it is |
+| --- | --- |
+| `README.md` | GitHub profile README (visitor-facing, not a build guide) |
+| `CONTRIBUTING.md` | Contribution guidelines — **read this first before opening a PR** |
+| `AGENTS.md` | Conventions for AI coding agents working in this repository |
+| `CLAUDE.md` | Claude-specific project instructions |
+| `SCHEMA.md` | Data/content schema documentation (relates to `_data/`) |
+| `SUBMODULES.md` | How the git submodules declared in `.gitmodules` are organised |
+| `docs/` | Longer-form documentation, including this page |
+| `fleet.manifest.yml` | Manifest describing automated agent work on this repository |
+
+### Site content
+
+| Path | What it is |
+| --- | --- |
+| `index.md` | Site landing page |
+| `pages/` | Additional content pages |
+| `_data/` | Structured data consumed by the site (see `SCHEMA.md`) |
+| `assets/` | Static assets (images, styles, scripts) |
+| `templates/` | Reusable templates — *purpose inferred from the directory name* |
+| `projects/` | Project entries — *purpose inferred from the directory name* |
+| `_reports/` | Generated reports — *purpose inferred from the directory name* |
+
+### Build and tooling
+
+| Path | Tool it configures | Where to look for details |
+| --- | --- | --- |
+| `Gemfile` | Ruby / Bundler dependencies | `Gemfile` (and `Gemfile.lock` if committed) |
+| `Rakefile` | Rake tasks — the repository's task runner | `Rakefile` for the full task list |
+| `_config.yml` | Site configuration (production) | `_config.yml` |
+| `_config_dev.yml` | Site configuration (development overrides) | `_config_dev.yml` |
+| `docker-compose.yml` | Containerised local environment | `docker-compose.yml` for service and port names |
+| `.devcontainer/` | VS Code / Codespaces Dev Container | `.devcontainer/devcontainer.json` |
+| `.pre-commit-config.yaml` | `pre-commit` hook definitions | `.pre-commit-config.yaml` |
+| `.husky/` | Git hooks | scripts inside `.husky/` |
+| `.prettierrc`, `.prettierignore` | Prettier formatting rules | the files themselves |
+| `.editorconfig` | Editor defaults (indentation, line endings) | `.editorconfig` |
+| `.env.example` | Template for local environment variables | copy and fill in as needed |
+| `.gitmodules` | Git submodule declarations | `SUBMODULES.md` |
+| `.github/` | CI workflows and repository templates | `.github/workflows/` |
+| `tools/` | Repository scripts — *purpose inferred from the directory name* |
+| `home.code-workspace` | VS Code multi-root workspace file | open in VS Code |
+| `.vscode/` | Shared editor settings and tasks | `.vscode/` |
+| `.zshrc`, `.zprofile`, `.gitconfig` | Dotfiles managed in this monorepo | the files themselves |
+| `.mcp.json` | Model Context Protocol server configuration | `.mcp.json` |
+| `.claude/` | Claude agent configuration | `.claude/` |
+
+The combination of `Gemfile`, `_config.yml`, `_config_dev.yml`, `_data/`,
+`index.md` and `assets/` is the conventional layout of a **Jekyll** site. Treat
+that as a strong inference rather than a confirmed fact until `_config.yml` is
+checked.
+
+## Getting a local checkout
+
+1. Clone the repository.
+2. **Submodules.** `.gitmodules` is present, so a plain clone will not fetch
+   everything. See [`SUBMODULES.md`](../SUBMODULES.md) for the procedure this
+   repository expects.
+3. **Environment variables.** `.env.example` exists; copy it to the filename
+   your tooling expects and fill in the values. **TODO:** document which
+   variables are required and what they do.
+
+### Three ways to get an environment
+
+This repository ships configuration for all three, so pick whichever suits you:
+
+- **Dev Container** — open the repository in VS Code or GitHub Codespaces and
+  reopen in the container defined by `.devcontainer/`. This is usually the
+  lowest-friction option because the toolchain is pinned for you.
+- **Docker Compose** — `docker-compose.yml` defines a containerised stack.
+  **TODO:** name the services and the port the site is served on.
+- **Native** — install Ruby and run Bundler against the `Gemfile`.
+  **TODO:** record the Ruby version this repository targets.
+
+## Common tasks
+
+**TODO — fill in from `Rakefile`, `docker-compose.yml` and `.pre-commit-config.yaml`.**
+These are intentionally left blank so that nobody copies a command that was
+never run against this repository.
+
+| Task | Command |
+| --- | --- |
+| Install dependencies | _TODO_ |
+| Serve the site locally | _TODO_ |
+| Build the site for production | _TODO_ |
+| List available Rake tasks | _TODO_ |
+| Run the linters / formatters | _TODO_ |
+| Run the test suite | _TODO_ |
+
+Until the table is filled in, `Rakefile` is the best single place to discover
+what automation already exists.
+
+## Checks that run before your commit lands
+
+Two hook systems are configured at the root:
+
+- **`pre-commit`** (`.pre-commit-config.yaml`) — Python-ecosystem hook manager.
+  Hooks defined here run against staged files. Install the hooks locally so you
+  find failures before CI does.
+- **Husky** (`.husky/`) — git hooks driven by the JavaScript ecosystem, likely
+  paired with the Prettier configuration (`.prettierrc`, `.prettierignore`).
+
+**TODO:** confirm how the two are meant to coexist, and which one owns
+formatting. Note that `.husky/` and `.prettierrc` normally accompany a
+`package.json`, which is not present at the repository root — worth clarifying.
+
+CI workflows live in `.github/workflows/`; those are the authoritative checks
+for a pull request.
+
+## Where to go next
+
+- Opening a pull request → [`CONTRIBUTING.md`](../CONTRIBUTING.md)
+- Editing structured content in `_data/` → [`SCHEMA.md`](../SCHEMA.md)
+- Working with submodules → [`SUBMODULES.md`](../SUBMODULES.md)
+- Working in this repository with an AI agent → [`AGENTS.md`](../AGENTS.md)
+  and [`CLAUDE.md`](../CLAUDE.md)
+
+## Improving this page
+
+If you fill in one of the TODOs above, please do it by reading the config file
+named alongside it and pasting the command you actually ran. A guide that is
+blank in places is more useful than one that is confidently wrong.

--- a/docs/development.md
+++ b/docs/development.md
@@ -12,19 +12,13 @@ description: Contributor-facing entry point for the bamr87/bamr87 monorepo.
 
 ## Start here (and not in the root README)
 
-The `README.md` at the root of this repository is a **GitHub profile README**.
-Its front matter reads `title: Amr Abdel-Motaleb - Solutions Architect & ERP
-Specialist`, and its audience is people visiting the `bamr87` GitHub profile —
-not people cloning the repository.
+The `README.md` at the root of this repository is a **GitHub profile README**. Its front matter reads `title: Amr Abdel-Motaleb - Solutions Architect & ERP Specialist`, and its audience is people visiting the `bamr87` GitHub profile — not people cloning the repository.
 
-This page is the counterpart: the entry point for anyone who wants to run,
-build, or change the code.
+This page is the counterpart: the entry point for anyone who wants to run, build, or change the code.
 
 ## Repository map
 
-The repository is described in its own metadata as a **monorepo**, primary
-language **Shell**, default branch **`main`**. Here is what lives at the top
-level.
+The repository is described in its own metadata as a **monorepo**, primary language **Shell**, default branch **`main`**. Here is what lives at the top level.
 
 ### Documentation
 
@@ -75,28 +69,22 @@ level.
 | `.mcp.json` | Model Context Protocol server configuration | `.mcp.json` |
 | `.claude/` | Claude agent configuration | `.claude/` |
 
-The combination of `Gemfile`, `_config.yml`, `_config_dev.yml`, `_data/`,
-`index.md` and `assets/` is the conventional layout of a **Jekyll** site. Treat
-that as a strong inference rather than a confirmed fact until `_config.yml` is
-checked.
+The combination of `Gemfile`, `_config.yml`, `_config_dev.yml`, `_data/`, `index.md` and `assets/` is the conventional layout of a **Jekyll** site. Treat that as a strong inference rather than a confirmed fact until `_config.yml` is checked.
 
 ## Getting a local checkout
 
 1. Clone the repository.
 2. **Submodules.** `.gitmodules` is present, so a plain clone will not fetch
-   everything. See [`SUBMODULES.md`](../SUBMODULES.md) for the procedure this
-   repository expects.
+everything. See [`SUBMODULES.md`](../SUBMODULES.md) for the procedure this repository expects.
 3. **Environment variables.** `.env.example` exists; copy it to the filename
-   your tooling expects and fill in the values. **TODO:** document which
-   variables are required and what they do.
+your tooling expects and fill in the values. **TODO:** document which variables are required and what they do.
 
 ### Three ways to get an environment
 
 This repository ships configuration for all three, so pick whichever suits you:
 
 - **Dev Container** — open the repository in VS Code or GitHub Codespaces and
-  reopen in the container defined by `.devcontainer/`. This is usually the
-  lowest-friction option because the toolchain is pinned for you.
+reopen in the container defined by `.devcontainer/`. This is usually the lowest-friction option because the toolchain is pinned for you.
 - **Docker Compose** — `docker-compose.yml` defines a containerised stack.
   **TODO:** name the services and the port the site is served on.
 - **Native** — install Ruby and run Bundler against the `Gemfile`.
@@ -104,9 +92,7 @@ This repository ships configuration for all three, so pick whichever suits you:
 
 ## Common tasks
 
-**TODO — fill in from `Rakefile`, `docker-compose.yml` and `.pre-commit-config.yaml`.**
-These are intentionally left blank so that nobody copies a command that was
-never run against this repository.
+**TODO — fill in from `Rakefile`, `docker-compose.yml` and `.pre-commit-config.yaml`.** These are intentionally left blank so that nobody copies a command that was never run against this repository.
 
 | Task | Command |
 | --- | --- |
@@ -117,25 +103,20 @@ never run against this repository.
 | Run the linters / formatters | _TODO_ |
 | Run the test suite | _TODO_ |
 
-Until the table is filled in, `Rakefile` is the best single place to discover
-what automation already exists.
+Until the table is filled in, `Rakefile` is the best single place to discover what automation already exists.
 
 ## Checks that run before your commit lands
 
 Two hook systems are configured at the root:
 
 - **`pre-commit`** (`.pre-commit-config.yaml`) — Python-ecosystem hook manager.
-  Hooks defined here run against staged files. Install the hooks locally so you
-  find failures before CI does.
+Hooks defined here run against staged files. Install the hooks locally so you find failures before CI does.
 - **Husky** (`.husky/`) — git hooks driven by the JavaScript ecosystem, likely
   paired with the Prettier configuration (`.prettierrc`, `.prettierignore`).
 
-**TODO:** confirm how the two are meant to coexist, and which one owns
-formatting. Note that `.husky/` and `.prettierrc` normally accompany a
-`package.json`, which is not present at the repository root — worth clarifying.
+**TODO:** confirm how the two are meant to coexist, and which one owns formatting. Note that `.husky/` and `.prettierrc` normally accompany a `package.json`, which is not present at the repository root — worth clarifying.
 
-CI workflows live in `.github/workflows/`; those are the authoritative checks
-for a pull request.
+CI workflows live in `.github/workflows/`; those are the authoritative checks for a pull request.
 
 ## Where to go next
 
@@ -147,6 +128,4 @@ for a pull request.
 
 ## Improving this page
 
-If you fill in one of the TODOs above, please do it by reading the config file
-named alongside it and pasting the command you actually ran. A guide that is
-blank in places is more useful than one that is confidently wrong.
+If you fill in one of the TODOs above, please do it by reading the config file named alongside it and pasting the command you actually ran. A guide that is blank in places is more useful than one that is confidently wrong.

--- a/docs/repository-layout.md
+++ b/docs/repository-layout.md
@@ -13,23 +13,16 @@ A newcomer's map of what lives at the root of this repository and why.
 
 ## The short version
 
-This repository wears two hats at once, which is the main thing that confuses
-first-time readers:
+This repository wears two hats at once, which is the main thing that confuses first-time readers:
 
 1. **A Jekyll site.** `_config.yml`, `Gemfile`, `index.md`, `_data/`, `pages/`
-   and `assets/` are the ingredients of a static site. Even `README.md` opens
-   with YAML front matter (`title:`, `author:`, `class:`, `updated:`), so it is
-   both the GitHub profile README *and* site content.
+and `assets/` are the ingredients of a static site. Even `README.md` opens with YAML front matter (`title:`, `author:`, `class:`, `updated:`), so it is both the GitHub profile README *and* site content.
 2. **A monorepo with automation around it.** `projects/`, `templates/`,
-   `tools/`, `_reports/`, `fleet.manifest.yml`, `.mcp.json`, `AGENTS.md` and
-   `CLAUDE.md` are about building, orchestrating and agent-driven workflows —
-   not about the site's HTML.
+`tools/`, `_reports/`, `fleet.manifest.yml`, `.mcp.json`, `AGENTS.md` and `CLAUDE.md` are about building, orchestrating and agent-driven workflows — not about the site's HTML.
 
-Everything else at the root is developer-environment plumbing: linting,
-formatting, hooks, containers, editor settings.
+Everything else at the root is developer-environment plumbing: linting, formatting, hooks, containers, editor settings.
 
-**`README.md` is a personal profile page, not a build guide.** Don't look there
-for setup instructions.
+**`README.md` is a personal profile page, not a build guide.** Don't look there for setup instructions.
 
 ---
 
@@ -43,8 +36,7 @@ for setup instructions.
 | Understand the git submodules and how to initialise them | `SUBMODULES.md` |
 | Understand how AI agents are expected to work in this repo | `AGENTS.md`, `CLAUDE.md` |
 
-(These files exist at the root — **verified** from the listing. Their contents
-are summarised here only by what their names claim; open them for the detail.)
+(These files exist at the root — **verified** from the listing. Their contents are summarised here only by what their names claim; open them for the detail.)
 
 ---
 
@@ -119,13 +111,9 @@ are summarised here only by what their names claim; open them for the detail.)
 
 ## Getting set up — **not yet documented here**
 
-This page deliberately contains **no install, build, serve or test commands**.
-The author of this page could not read `Gemfile`, `Rakefile`, `_config.yml`,
-`docker-compose.yml` or `.devcontainer/`, and writing commands that were never
-verified is worse than writing none.
+This page deliberately contains **no install, build, serve or test commands**. The author of this page could not read `Gemfile`, `Rakefile`, `_config.yml`, `docker-compose.yml` or `.devcontainer/`, and writing commands that were never verified is worse than writing none.
 
-Until this section is filled in, the authoritative sources are, in rough order
-of usefulness:
+Until this section is filled in, the authoritative sources are, in rough order of usefulness:
 
 1. `.devcontainer/` — if a dev container is defined, opening the repo in it is
    usually the shortest path to a working environment.
@@ -137,8 +125,7 @@ of usefulness:
 
 ### TODO for a maintainer
 
-Replace this section with the real commands, copied verbatim from the files
-above:
+Replace this section with the real commands, copied verbatim from the files above:
 
 The repository root `README.md` is a **GitHub profile README** — it renders on
 <https://github.com/bamr87> and describes the author, not the codebase. That is

--- a/docs/repository-map.md
+++ b/docs/repository-map.md
@@ -6,15 +6,13 @@ updated: 2026-08-26
 
 # Repository Map
 
-This repository is a **monorepo**. The root `README.md` is a GitHub *profile* README — it
-introduces the author, not the codebase — so this page exists to answer a different question:
+This repository is a **monorepo**. The root `README.md` is a GitHub *profile* README — it introduces the author, not the codebase — so this page exists to answer a different question:
 
 > "I want to change something. Which directory do I open?"
 
 ## How to read this page
 
-Each entry below is present in the repository root. The **Status** column tells you how much
-trust to place in the description:
+Each entry below is present in the repository root. The **Status** column tells you how much trust to place in the description:
 
 | Marker | Meaning |
 | --- | --- |
@@ -22,8 +20,7 @@ trust to place in the description:
 | 🔍 **Inferred** | The entry exists; the description follows from naming convention and from other files in this repo, but the contents were not read. |
 | ⚠️ **Unverified** | The entry exists, but its purpose is a placeholder awaiting a maintainer. **Do not rely on this row.** |
 
-If you correct a row, please also drop its marker down to ✅ — that is the whole maintenance
-burden of this page.
+If you correct a row, please also drop its marker down to ✅ — that is the whole maintenance burden of this page.
 
 ---
 
@@ -73,8 +70,7 @@ The root holds several Markdown files that are worth knowing about before you co
 
 ## Tooling, environment, and hooks
 
-These exist to keep contributions consistent. You rarely need to edit them, but it helps to
-know why a commit was rejected.
+These exist to keep contributions consistent. You rarely need to edit them, but it helps to know why a commit was rejected.
 
 | Path | What it is | Status |
 | --- | --- | --- |
@@ -100,22 +96,17 @@ know why a commit was rejected.
 | `.zshrc`, `.zprofile` | Zsh shell configuration, tracked in the repository. |
 | `.gitconfig` | Git configuration, tracked in the repository. |
 
-These are unusual to find in a project repository and are a strong hint that this monorepo
-doubles as a **dotfiles / home-environment repository** (the `home.code-workspace` filename
-points the same way). ⚠️ This reading is an inference and should be confirmed by a maintainer.
+These are unusual to find in a project repository and are a strong hint that this monorepo doubles as a **dotfiles / home-environment repository** (the `home.code-workspace` filename points the same way). ⚠️ This reading is an inference and should be confirmed by a maintainer.
 
 ---
 
 ## Working with submodules
 
-`.gitmodules` is present, which means a plain `git clone` will leave some directories empty.
-Refer to **`SUBMODULES.md`** for the project's own instructions — this page intentionally does
-not restate clone or update commands, because those were not verified against that file.
+`.gitmodules` is present, which means a plain `git clone` will leave some directories empty. Refer to **`SUBMODULES.md`** for the project's own instructions — this page intentionally does not restate clone or update commands, because those were not verified against that file.
 
 ## Open questions for maintainers
 
-The following could not be determined from the repository listing alone. Answering them here
-would make this page complete:
+The following could not be determined from the repository listing alone. Answering them here would make this page complete:
 
 1. What is the actual purpose and content convention of `pages/`, `projects/`, `templates/`,
    `tools/`, and `_reports/`?
@@ -124,11 +115,9 @@ would make this page complete:
    the agent fleet?
 4. How is `_config_dev.yml` applied relative to `_config.yml`?
 5. What are the canonical commands to install dependencies, serve the site locally, and run
-   checks? (Candidates live in `Gemfile`, `Rakefile`, and `docker-compose.yml`, but were not
-   verified — no commands are asserted here rather than risk publishing one that fails.)
+checks? (Candidates live in `Gemfile`, `Rakefile`, and `docker-compose.yml`, but were not verified — no commands are asserted here rather than risk publishing one that fails.)
 6. Are Husky and pre-commit both active, or is one superseded?
 
 ## Contributing to this page
 
-This map is only useful if it stays true. If you add or rename a top-level directory, please
-add or update its row in the same change.
+This map is only useful if it stays true. If you add or rename a top-level directory, please add or update its row in the same change.


### PR DESCRIPTION
## Why

`README.md` at the repository root is a **GitHub profile README** (front matter `title: Amr Abdel-Motaleb - Solutions Architect & ERP Specialist`). It serves recruiters, clients and visitors — and it does that well. What it does not do is answer a contributor's first three questions: *how do I run this locally, how do I build the site, and how do I run the checks?*

Meanwhile the root of this repository carries a real developer toolchain — `Gemfile`, `Rakefile`, `docker-compose.yml`, `.devcontainer/`, `.pre-commit-config.yaml`, `.husky/`, `_config.yml` / `_config_dev.yml`, `.gitmodules` — and five separate companion docs (`AGENTS.md`, `CLAUDE.md`, `CONTRIBUTING.md`, `SCHEMA.md`, `SUBMODULES.md`) plus a `docs/` directory. There is no single page that ties them together.

## What this PR does

Adds **`docs/development.md`**: a contributor entry point that

- states plainly that the root README is a profile README and points developers here,
- maps every top-level file and directory to its purpose,
- indexes the existing docs (`AGENTS.md`, `CLAUDE.md`, `CONTRIBUTING.md`, `SCHEMA.md`, `SUBMODULES.md`, `docs/`, `fleet.manifest.yml`) so they stop being scattered,
- lists the toolchain signals (Bundler, Rake, Docker Compose, Dev Containers, pre-commit, Husky, Jekyll, git submodules) with a pointer to the config file that defines each.

Documentation only — no code, no config, no changes to `README.md`.

## ⚠️ What I could **not** verify — please check before merging

This run had access to the top-level file listing and the profile README **only**. I could not open the contents of any config file, so this draft contains **no commands at all**. Everything below is left as an explicit TODO in the document:

1. **`CONTRIBUTING.md` already exists and I could not read it.** If it already covers local setup, this page should shrink to a pure index and link there instead of duplicating. Please reconcile the two.
2. **No build/serve/test commands are stated.** The "Common tasks" section is a TODO table. Filling it in requires reading `Rakefile` (task names), `Gemfile` (Ruby/gem versions), `docker-compose.yml` (service and port names) and `package.json`, if one exists under a subdirectory — I did not see one at the root, yet `.husky/` and `.prettierrc` normally imply a Node toolchain, which is an inconsistency worth resolving.
3. **Jekyll is inferred, not confirmed.** `_config.yml`, `_config_dev.yml`, `_data/`, `index.md`, `pages/`, `assets/` and a `Gemfile` together strongly suggest Jekyll (and the profile README lists Jekyll among the author's tools), but I have not read `_config.yml` to confirm the generator or theme.
4. **The purpose of `projects/`, `templates/`, `tools/`, `_reports/` and `.claude/` is inferred from their names.** Each is flagged in the document; please correct any that are wrong.
5. **Submodules:** `.gitmodules` exists and `SUBMODULES.md` presumably explains it, but I have not read either, so the page only links out rather than describing the clone procedure.
6. **`.env.example` exists**, so some configuration is environment-driven, but I do not know which variables are required.

If you would rather this content live inside `CONTRIBUTING.md` than in `docs/development.md`, say so and it can be moved wholesale — the structure is designed to work either way.

---
🤖 wtd fleet · `doc-writer` agent · item `bamr87/bamr87:write_docs:edd4d1b0b12e`
<!-- wtd-fleet:bamr87/bamr87:write_docs:edd4d1b0b12e -->