### PR TITLE
docs: add repository toolchain map (draft — command sections pending file review)

### DIFF
--- a/docs/repository-layout.md
+++ b/docs/repository-layout.md
@@ -13,23 +13,16 @@ A newcomer's map of what lives at the root of this repository and why.
 
 ## The short version
 
-This repository wears two hats at once, which is the main thing that confuses
-first-time readers:
+This repository wears two hats at once, which is the main thing that confuses first-time readers:
 
 1. **A Jekyll site.** `_config.yml`, `Gemfile`, `index.md`, `_data/`, `pages/`
-   and `assets/` are the ingredients of a static site. Even `README.md` opens
-   with YAML front matter (`title:`, `author:`, `class:`, `updated:`), so it is
-   both the GitHub profile README *and* site content.
+and `assets/` are the ingredients of a static site. Even `README.md` opens with YAML front matter (`title:`, `author:`, `class:`, `updated:`), so it is both the GitHub profile README *and* site content.
 2. **A monorepo with automation around it.** `projects/`, `templates/`,
-   `tools/`, `_reports/`, `fleet.manifest.yml`, `.mcp.json`, `AGENTS.md` and
-   `CLAUDE.md` are about building, orchestrating and agent-driven workflows —
-   not about the site's HTML.
+`tools/`, `_reports/`, `fleet.manifest.yml`, `.mcp.json`, `AGENTS.md` and `CLAUDE.md` are about building, orchestrating and agent-driven workflows — not about the site's HTML.
 
-Everything else at the root is developer-environment plumbing: linting,
-formatting, hooks, containers, editor settings.
+Everything else at the root is developer-environment plumbing: linting, formatting, hooks, containers, editor settings.
 
-**`README.md` is a personal profile page, not a build guide.** Don't look there
-for setup instructions.
+**`README.md` is a personal profile page, not a build guide.** Don't look there for setup instructions.
 
 ---
 
@@ -43,8 +36,7 @@ for setup instructions.
 | Understand the git submodules and how to initialise them | `SUBMODULES.md` |
 | Understand how AI agents are expected to work in this repo | `AGENTS.md`, `CLAUDE.md` |
 
-(These files exist at the root — **verified** from the listing. Their contents
-are summarised here only by what their names claim; open them for the detail.)
+(These files exist at the root — **verified** from the listing. Their contents are summarised here only by what their names claim; open them for the detail.)
 
 ---
 
@@ -119,13 +111,9 @@ are summarised here only by what their names claim; open them for the detail.)
 
 ## Getting set up — **not yet documented here**
 
-This page deliberately contains **no install, build, serve or test commands**.
-The author of this page could not read `Gemfile`, `Rakefile`, `_config.yml`,
-`docker-compose.yml` or `.devcontainer/`, and writing commands that were never
-verified is worse than writing none.
+This page deliberately contains **no install, build, serve or test commands**. The author of this page could not read `Gemfile`, `Rakefile`, `_config.yml`, `docker-compose.yml` or `.devcontainer/`, and writing commands that were never verified is worse than writing none.
 
-Until this section is filled in, the authoritative sources are, in rough order
-of usefulness:
+Until this section is filled in, the authoritative sources are, in rough order of usefulness:
 
 1. `.devcontainer/` — if a dev container is defined, opening the repo in it is
    usually the shortest path to a working environment.
@@ -137,8 +125,7 @@ of usefulness:
 
 ### TODO for a maintainer
 
-Replace this section with the real commands, copied verbatim from the files
-above:
+Replace this section with the real commands, copied verbatim from the files above:
 
 The repository root `README.md` is a **GitHub profile README** — it renders on
 <https://github.com/bamr87> and describes the author, not the codebase. That is

--- a/docs/repository-map.md
+++ b/docs/repository-map.md
@@ -6,15 +6,13 @@ updated: 2026-08-26
 
 # Repository Map
 
-This repository is a **monorepo**. The root `README.md` is a GitHub *profile* README — it
-introduces the author, not the codebase — so this page exists to answer a different question:
+This repository is a **monorepo**. The root `README.md` is a GitHub *profile* README — it introduces the author, not the codebase — so this page exists to answer a different question:
 
 > "I want to change something. Which directory do I open?"
 
 ## How to read this page
 
-Each entry below is present in the repository root. The **Status** column tells you how much
-trust to place in the description:
+Each entry below is present in the repository root. The **Status** column tells you how much trust to place in the description:
 
 | Marker | Meaning |
 | --- | --- |
@@ -22,8 +20,7 @@ trust to place in the description:
 | 🔍 **Inferred** | The entry exists; the description follows from naming convention and from other files in this repo, but the contents were not read. |
 | ⚠️ **Unverified** | The entry exists, but its purpose is a placeholder awaiting a maintainer. **Do not rely on this row.** |
 
-If you correct a row, please also drop its marker down to ✅ — that is the whole maintenance
-burden of this page.
+If you correct a row, please also drop its marker down to ✅ — that is the whole maintenance burden of this page.
 
 ---
 
@@ -73,8 +70,7 @@ The root holds several Markdown files that are worth knowing about before you co
 
 ## Tooling, environment, and hooks
 
-These exist to keep contributions consistent. You rarely need to edit them, but it helps to
-know why a commit was rejected.
+These exist to keep contributions consistent. You rarely need to edit them, but it helps to know why a commit was rejected.
 
 | Path | What it is | Status |
 | --- | --- | --- |
@@ -100,22 +96,17 @@ know why a commit was rejected.
 | `.zshrc`, `.zprofile` | Zsh shell configuration, tracked in the repository. |
 | `.gitconfig` | Git configuration, tracked in the repository. |
 
-These are unusual to find in a project repository and are a strong hint that this monorepo
-doubles as a **dotfiles / home-environment repository** (the `home.code-workspace` filename
-points the same way). ⚠️ This reading is an inference and should be confirmed by a maintainer.
+These are unusual to find in a project repository and are a strong hint that this monorepo doubles as a **dotfiles / home-environment repository** (the `home.code-workspace` filename points the same way). ⚠️ This reading is an inference and should be confirmed by a maintainer.
 
 ---
 
 ## Working with submodules
 
-`.gitmodules` is present, which means a plain `git clone` will leave some directories empty.
-Refer to **`SUBMODULES.md`** for the project's own instructions — this page intentionally does
-not restate clone or update commands, because those were not verified against that file.
+`.gitmodules` is present, which means a plain `git clone` will leave some directories empty. Refer to **`SUBMODULES.md`** for the project's own instructions — this page intentionally does not restate clone or update commands, because those were not verified against that file.
 
 ## Open questions for maintainers
 
-The following could not be determined from the repository listing alone. Answering them here
-would make this page complete:
+The following could not be determined from the repository listing alone. Answering them here would make this page complete:
 
 1. What is the actual purpose and content convention of `pages/`, `projects/`, `templates/`,
    `tools/`, and `_reports/`?
@@ -124,11 +115,9 @@ would make this page complete:
    the agent fleet?
 4. How is `_config_dev.yml` applied relative to `_config.yml`?
 5. What are the canonical commands to install dependencies, serve the site locally, and run
-   checks? (Candidates live in `Gemfile`, `Rakefile`, and `docker-compose.yml`, but were not
-   verified — no commands are asserted here rather than risk publishing one that fails.)
+checks? (Candidates live in `Gemfile`, `Rakefile`, and `docker-compose.yml`, but were not verified — no commands are asserted here rather than risk publishing one that fails.)
 6. Are Husky and pre-commit both active, or is one superseded?
 
 ## Contributing to this page
 
-This map is only useful if it stays true. If you add or rename a top-level directory, please
-add or update its row in the same change.
+This map is only useful if it stays true. If you add or rename a top-level directory, please add or update its row in the same change.

--- a/docs/repository-toolchain.md
+++ b/docs/repository-toolchain.md
@@ -1,0 +1,147 @@
+---
+title: Repository Toolchain Map
+status: draft
+---
+
+# Repository Toolchain Map
+
+> **Status: draft.** This document was assembled from the repository's root file
+> listing only. The configuration files themselves had not been read when it was
+> written, so it deliberately contains **no install, serve, build or test
+> commands** — those would have been guesses. Sections marked `TODO` are genuine
+> unknowns; see [Unverified — needs confirmation](#unverified--needs-confirmation).
+
+## What this repository is
+
+`bamr87/bamr87` is a monorepo that doubles as the owner's GitHub profile
+repository. The root `README.md` renders as the profile page; the rest of the
+tree (`pages/`, `projects/`, `docs/`, `templates/`, `tools/`, `_data/`,
+`assets/`) holds the monorepo's actual content and automation.
+
+The root configuration files imply a stack with four distinct layers:
+
+1. a **Ruby / Jekyll** static site,
+2. a **containerised** development environment (Docker Compose + Dev Containers),
+3. **git hooks** for pre-commit quality gates, from two independent hook managers,
+4. **shell / editor** environment configuration checked into the repo itself.
+
+Each layer is inventoried below.
+
+---
+
+## Layer 1 — Ruby and the static site
+
+| File | Tool it belongs to | What it means here |
+| --- | --- | --- |
+| `Gemfile` | [Bundler](https://bundler.io/) | Declares the Ruby gem dependencies. A `Gemfile.lock` is not present in the root listing, which usually means it is either gitignored or generated in the container. |
+| `Rakefile` | [Rake](https://ruby.github.io/rake/) | Defines the repository's task entry points. This is the most likely home for the project's build/serve/test commands. |
+| `_config.yml` | [Jekyll](https://jekyllrb.com/) | Jekyll's primary site configuration. Its presence alongside `index.md`, `_data/`, `assets/` and underscore-prefixed directories is the main evidence that the site is built with Jekyll. |
+| `_config_dev.yml` | Jekyll | A second configuration profile, conventionally layered *on top of* `_config.yml` for local development. |
+
+Jekyll supports being given more than one config file, with later files
+overriding earlier ones — which is the usual reason a `_config_dev.yml` exists
+alongside `_config.yml`. **How this repository actually combines the two is not
+yet documented here** (`TODO`).
+
+---
+
+## Layer 2 — Containerised development
+
+| File / directory | Tool it belongs to | What it means here |
+| --- | --- | --- |
+| `docker-compose.yml` | [Docker Compose](https://docs.docker.com/compose/) | Defines the service(s) used to run the project without installing Ruby locally. |
+| `.devcontainer/` | [Dev Containers](https://containers.dev/) | Lets VS Code (or GitHub Codespaces) open the repository directly inside a container. |
+| `.env.example` | environment variables | A template for a local, untracked `.env`. Copy it and fill it in before starting the containers. The variables it declares are not documented here (`TODO`). |
+| `home.code-workspace` | VS Code | A multi-root workspace file — consistent with a monorepo that also uses git submodules. |
+
+Because both a Compose file and a Dev Container definition exist, there are
+probably **two supported ways to get a working environment** (open in a dev
+container, or bring up Compose by hand), plus a third native path via Bundler.
+Which one the maintainer considers canonical is not yet recorded (`TODO`).
+
+---
+
+## Layer 3 — Git hooks and formatting
+
+This repository carries **two** hook managers, which is unusual and worth
+understanding before you commit:
+
+| File / directory | Tool it belongs to | What it means here |
+| --- | --- | --- |
+| `.pre-commit-config.yaml` | [pre-commit](https://pre-commit.com/) (Python) | Declares hooks that run before each commit. Requires a one-time install step to activate the git hook. |
+| `.husky/` | [Husky](https://typicode.github.io/husky/) (Node.js) | A second, Node-based git hook manager. Its hook scripts live as files inside this directory. |
+| `.prettierrc` | [Prettier](https://prettier.io/) | Formatting rules. |
+| `.prettierignore` | Prettier | Paths excluded from formatting. |
+| `.editorconfig` | [EditorConfig](https://editorconfig.org/) | Editor-level whitespace/charset settings, applied automatically by most editors. |
+
+The presence of `.prettierrc` implies a Node.js toolchain, but **no
+`package.json` appears in the root listing.** That is worth resolving — Husky
+normally expects one — and is recorded as an open question below.
+
+---
+
+## Layer 4 — Shell, submodules and agent configuration
+
+| File / directory | What it is |
+| --- | --- |
+| `.gitmodules` | Git submodule definitions. The repository is a monorepo of linked repositories; see `SUBMODULES.md` for the maintainer's own notes. |
+| `tools/` | The repository's scripts. The manifest reports Shell as the primary language, which is consistent with this directory, though its contents are not described here (`TODO`). |
+| `.zshrc`, `.zprofile`, `.gitconfig` | Dotfiles tracked in-repo — this repository doubles as a dotfiles source. |
+| `.github/` | GitHub configuration: workflows, issue templates, and similar. |
+| `.vscode/` | Shared editor settings. |
+| `.claude/`, `.mcp.json`, `AGENTS.md`, `CLAUDE.md` | AI-agent configuration and instructions for tooling that operates on this repository. |
+| `fleet.manifest.yml` | Manifest describing the repository to automation. |
+| `SCHEMA.md`, `SUBMODULES.md`, `CONTRIBUTING.md` | Existing maintainer documentation. Read `CONTRIBUTING.md` first if you intend to open a PR. |
+| `_reports/` | Generated or collected reports. |
+
+---
+
+## Unverified — needs confirmation
+
+Everything below is an open question. Answering these turns this map into a
+usable getting-started guide. Each item names the exact file to read.
+
+### Commands
+
+- [ ] **`Rakefile`** — list the defined tasks. Which one serves the site
+      locally, which builds it, which runs tests or linting? Record the exact
+      `rake` invocations.
+- [ ] **`Gemfile`** — confirm that `jekyll` is actually a declared dependency,
+      note the required Ruby version, and list any gem groups (e.g. a
+      development-only group) that change the install step.
+- [ ] **`docker-compose.yml`** — record the service names, the published port(s)
+      for the local site, and the exact command used to bring the stack up.
+- [ ] **`.devcontainer/`** — record the base image and any post-create command,
+      so newcomers know what is already installed for them.
+
+### Configuration profiles
+
+- [ ] **`_config_dev.yml` vs `_config.yml`** — document precisely what the dev
+      profile overrides (baseurl? url? host? plugins? `future`/`drafts`
+      settings?) and how the two are combined at build time.
+
+### Hooks
+
+- [ ] **`.pre-commit-config.yaml`** — list each hook, what it checks, and the
+      one-time command required to install the git hook.
+- [ ] **`.husky/`** — list the hook scripts present and what each one runs.
+- [ ] **Why both managers?** Determine whether pre-commit and Husky cover
+      different file types, or whether one supersedes the other. Newcomers need
+      to know which to install.
+- [ ] **Missing `package.json`** — Husky and Prettier normally require a Node
+      project manifest. Confirm whether one lives elsewhere in the tree, whether
+      it is generated, or whether these tools are invoked another way.
+
+### Environment
+
+- [ ] **`.env.example`** — document each variable, whether it is required, and
+      what a safe local value looks like.
+- [ ] **`tools/`** — summarise what the scripts do and which are entry points
+      intended for humans.
+
+### Contribution flow
+
+- [ ] **`CONTRIBUTING.md`** — cross-check this document against it and remove
+      any duplication, or fold this file into it entirely.
+- [ ] **`.github/`** — record which CI workflows run on a pull request, so
+      contributors know what must pass.

--- a/docs/repository-toolchain.md
+++ b/docs/repository-toolchain.md
@@ -13,10 +13,7 @@ status: draft
 
 ## What this repository is
 
-`bamr87/bamr87` is a monorepo that doubles as the owner's GitHub profile
-repository. The root `README.md` renders as the profile page; the rest of the
-tree (`pages/`, `projects/`, `docs/`, `templates/`, `tools/`, `_data/`,
-`assets/`) holds the monorepo's actual content and automation.
+`bamr87/bamr87` is a monorepo that doubles as the owner's GitHub profile repository. The root `README.md` renders as the profile page; the rest of the tree (`pages/`, `projects/`, `docs/`, `templates/`, `tools/`, `_data/`, `assets/`) holds the monorepo's actual content and automation.
 
 The root configuration files imply a stack with four distinct layers:
 
@@ -38,10 +35,7 @@ Each layer is inventoried below.
 | `_config.yml` | [Jekyll](https://jekyllrb.com/) | Jekyll's primary site configuration. Its presence alongside `index.md`, `_data/`, `assets/` and underscore-prefixed directories is the main evidence that the site is built with Jekyll. |
 | `_config_dev.yml` | Jekyll | A second configuration profile, conventionally layered *on top of* `_config.yml` for local development. |
 
-Jekyll supports being given more than one config file, with later files
-overriding earlier ones — which is the usual reason a `_config_dev.yml` exists
-alongside `_config.yml`. **How this repository actually combines the two is not
-yet documented here** (`TODO`).
+Jekyll supports being given more than one config file, with later files overriding earlier ones — which is the usual reason a `_config_dev.yml` exists alongside `_config.yml`. **How this repository actually combines the two is not yet documented here** (`TODO`).
 
 ---
 
@@ -54,17 +48,13 @@ yet documented here** (`TODO`).
 | `.env.example` | environment variables | A template for a local, untracked `.env`. Copy it and fill it in before starting the containers. The variables it declares are not documented here (`TODO`). |
 | `home.code-workspace` | VS Code | A multi-root workspace file — consistent with a monorepo that also uses git submodules. |
 
-Because both a Compose file and a Dev Container definition exist, there are
-probably **two supported ways to get a working environment** (open in a dev
-container, or bring up Compose by hand), plus a third native path via Bundler.
-Which one the maintainer considers canonical is not yet recorded (`TODO`).
+Because both a Compose file and a Dev Container definition exist, there are probably **two supported ways to get a working environment** (open in a dev container, or bring up Compose by hand), plus a third native path via Bundler. Which one the maintainer considers canonical is not yet recorded (`TODO`).
 
 ---
 
 ## Layer 3 — Git hooks and formatting
 
-This repository carries **two** hook managers, which is unusual and worth
-understanding before you commit:
+This repository carries **two** hook managers, which is unusual and worth understanding before you commit:
 
 | File / directory | Tool it belongs to | What it means here |
 | --- | --- | --- |
@@ -74,9 +64,7 @@ understanding before you commit:
 | `.prettierignore` | Prettier | Paths excluded from formatting. |
 | `.editorconfig` | [EditorConfig](https://editorconfig.org/) | Editor-level whitespace/charset settings, applied automatically by most editors. |
 
-The presence of `.prettierrc` implies a Node.js toolchain, but **no
-`package.json` appears in the root listing.** That is worth resolving — Husky
-normally expects one — and is recorded as an open question below.
+The presence of `.prettierrc` implies a Node.js toolchain, but **no `package.json` appears in the root listing.** That is worth resolving — Husky normally expects one — and is recorded as an open question below.
 
 ---
 
@@ -98,8 +86,7 @@ normally expects one — and is recorded as an open question below.
 
 ## Unverified — needs confirmation
 
-Everything below is an open question. Answering these turns this map into a
-usable getting-started guide. Each item names the exact file to read.
+Everything below is an open question. Answering these turns this map into a usable getting-started guide. Each item names the exact file to read.
 
 ### Commands
 


### PR DESCRIPTION
## What this is

A **draft** `docs/repository-toolchain.md` that inventories the configuration files at the repository root and explains, for a newcomer, which toolchain each one implies.

## Why it is incomplete on purpose

The work item asked me to "document the toolchain implied by the repo root once its config files have been read". The config files were **not** available to me — the evidence I received was the top-level directory listing and the current `README.md` only. I therefore did **not** write any install/serve/build/test commands, because I would have had to invent them.

What the document does contain is verifiable from the file listing alone:

- an inventory of every root config file that exists (`Gemfile`, `Rakefile`, `_config.yml`, `_config_dev.yml`, `docker-compose.yml`, `.devcontainer/`, `.env.example`, `.pre-commit-config.yaml`, `.husky/`, `.prettierrc`, `.prettierignore`, `.editorconfig`, `.gitmodules`, `.mcp.json`, `tools/`, `home.code-workspace`);
- what family of tooling each filename belongs to (Bundler/Ruby, Rake, Jekyll, Docker Compose, Dev Containers, pre-commit, Husky, Prettier, EditorConfig, git submodules);
- a clearly-marked **"Unverified — needs confirmation"** section listing the precise question to answer against each file.

Every statement that goes beyond "this file exists" is either a statement about the filename convention or is placed under the unverified heading and marked `TODO`.

## Things a human should check before merging

1. **Overlap with existing docs.** The repo already has `docs/`, `CONTRIBUTING.md`, `CLAUDE.md`, `AGENTS.md`, `SCHEMA.md` and `SUBMODULES.md`. I could not read any of them. If one of these already documents the toolchain, this file should be merged into it or dropped rather than added.
2. **File path.** I chose `docs/repository-toolchain.md` blind; rename it to match whatever naming convention `docs/` already uses.
3. **Every `TODO` marker.** None of them are placeholders for prose I know the answer to — they are genuine unknowns. Do not merge with them unresolved unless the file is explicitly landed as a checklist.
4. **Ruby/Jekyll assumption.** `Gemfile` + `_config.yml` + `index.md` + `assets/` is a strong signal of Jekyll, and the current README mentions "Jekyll static site generators" under the author's skills, but I have not seen `jekyll` declared as a dependency. The document flags this as inferred, not confirmed.
5. **Repository language.** The manifest reports the primary language as Shell, which fits `tools/`, `.zshrc`, `.zprofile` and `.gitconfig`, but I have not read anything in `tools/`, so the document does not characterise its contents.

Happy for this to be closed if the maintainer would rather a follow-up run land the fully-verified version in one go.

---
🤖 wtd fleet · `doc-writer` agent · item `bamr87/bamr87:write_docs:e72ec56d253e`
<!-- wtd-fleet:bamr87/bamr87:write_docs:e72ec56d253e -->