### PR TITLE
docs: add contributor guide for pre-commit, husky, Prettier, and markdownlint hooks

### DIFF
--- a/docs/git-hooks.md
+++ b/docs/git-hooks.md
@@ -1,0 +1,181 @@
+---
+title: Git Hooks & Local Checks
+description: How to install and run this repository's pre-commit, husky, Prettier, and markdownlint checks.
+---
+
+# Git Hooks & Local Checks
+
+This repository ships configuration for several automated checks that run against
+your changes. They are **configured** when you clone, but most of them are not
+**installed** until you run a setup command — so a fresh clone will happily let you
+commit code that the tooling would otherwise flag.
+
+This page covers the one-time setup and the manual commands you can run any time.
+
+## What ships in this repository
+
+| File / directory | Tool it belongs to | What it controls |
+| --- | --- | --- |
+| `.pre-commit-config.yaml` | [pre-commit](https://pre-commit.com/) | The set of hooks pre-commit runs before each commit |
+| `.husky/` | [husky](https://typicode.github.io/husky/) | Git hook scripts managed via Git's `core.hooksPath` |
+| `.prettierrc` | [Prettier](https://prettier.io/) | Formatting rules |
+| `.prettierignore` | Prettier | Paths Prettier should not format |
+| `.markdownlintignore` | [markdownlint-cli](https://github.com/igorshubovych/markdownlint-cli) | Paths excluded from Markdown linting |
+| `.editorconfig` | [EditorConfig](https://editorconfig.org/) | Editor-level whitespace/charset defaults (applied by your editor, no install step) |
+
+Open `.pre-commit-config.yaml` and the scripts in `.husky/` for the authoritative,
+up-to-date list of what actually runs — the configs are the source of truth, and
+they change more often than this page does.
+
+## One-time setup
+
+### 1. Install the pre-commit hooks
+
+`pre-commit` is a standalone tool; installing this repository's dependencies does
+not install it for you. Pick whichever channel suits your machine:
+
+```bash
+# any one of these
+pip install pre-commit
+pipx install pre-commit
+brew install pre-commit
+```
+
+Then, from the repository root, wire it into your local `.git/hooks`:
+
+```bash
+pre-commit install
+```
+
+From this point on, the hooks declared in `.pre-commit-config.yaml` run
+automatically against your **staged** files each time you `git commit`.
+
+> The first run downloads and caches each hook's environment, so expect it to be
+> noticeably slower than subsequent runs.
+
+### 2. Enable the husky hooks
+
+The `.husky/` directory holds Git hook scripts. Husky works by pointing Git's
+`core.hooksPath` setting at that directory — until that setting exists in your
+local clone, the scripts in `.husky/` are inert.
+
+If the project exposes an npm `prepare` script that runs husky, installing the
+Node dependencies is enough:
+
+```bash
+npm install
+```
+
+Otherwise you can point Git at the directory yourself:
+
+```bash
+git config core.hooksPath .husky
+```
+
+Verify which one applies with:
+
+```bash
+git config --get core.hooksPath   # should print: .husky
+```
+
+> **Verify:** there is no `package.json` at the repository root, so the `npm install`
+> route may not apply here (or may need to be run from a subdirectory). Confirm the
+> intended bootstrap path with a maintainer and prune whichever option is wrong.
+
+> **Note:** `pre-commit install` and husky both want to own your Git hooks. If both
+> are in use, check whether one already invokes the other before enabling both, so
+> you don't end up running the same checks twice — or, worse, silently replacing one
+> set of hooks with the other.
+
+## Running the checks manually
+
+You do not need to make a commit to exercise the checks. This is the fastest way to
+reproduce a CI failure locally.
+
+### pre-commit
+
+```bash
+# run every hook against every file in the repo
+pre-commit run --all-files
+
+# run every hook against only your staged changes
+pre-commit run
+
+# run a single hook by its id (ids are listed in .pre-commit-config.yaml)
+pre-commit run <hook-id> --all-files
+```
+
+To pull newer versions of the pinned hook repositories:
+
+```bash
+pre-commit autoupdate
+```
+
+### Prettier
+
+`.prettierrc` and `.prettierignore` are picked up automatically when you run
+Prettier from the repository root. Prettier requires Node.js.
+
+```bash
+# report files that are not formatted (non-zero exit if any are found)
+npx prettier --check .
+
+# rewrite them in place
+npx prettier --write .
+```
+
+### markdownlint
+
+`.markdownlintignore` is the ignore file read by `markdownlint-cli`:
+
+```bash
+npx markdownlint-cli '**/*.md'
+```
+
+> **Verify:** `markdownlint-cli` and `markdownlint-cli2` are different packages with
+> different ignore-file conventions. Confirm which one this repository uses (check
+> `.pre-commit-config.yaml` and CI workflow files) and delete the other from this
+> section.
+
+## Skipping hooks
+
+Sometimes you need to land a commit without running the hooks — a work-in-progress
+commit on a scratch branch, or an emergency fix. Use this sparingly: whatever the
+hooks catch locally will usually be caught again in review or CI.
+
+```bash
+# skip all Git hooks for a single commit (works for both pre-commit and husky)
+git commit --no-verify -m "wip"
+
+# skip specific pre-commit hooks by id
+SKIP=<hook-id>,<other-hook-id> git commit -m "..."
+```
+
+## Troubleshooting
+
+**`pre-commit: command not found` on commit.** The hook script was installed but the
+executable is not on your `PATH` — common with `pip install --user`. Reinstall via
+`pipx` or `brew`, or add the user script directory to your `PATH`.
+
+**Hooks don't run at all.** Confirm the installation actually happened:
+
+```bash
+ls .git/hooks/pre-commit          # pre-commit writes a shim here
+git config --get core.hooksPath   # husky sets this to .husky
+```
+
+Note that if `core.hooksPath` is set, Git ignores `.git/hooks/` entirely — that is
+the usual reason a `pre-commit install` appears to have no effect.
+
+**A hook fails on files you didn't touch.** Formatters run over whatever they are
+given; if a hook was recently added, pre-existing files may fail on their first run.
+Raise it with a maintainer rather than reformatting unrelated files inside a
+feature branch.
+
+**Hook environments look stale after a config change.** Clear the cached
+environments and let pre-commit rebuild them:
+
+```bash
+pre-commit clean
+pre-commit run --all-files
+```

--- a/docs/git-hooks.md
+++ b/docs/git-hooks.md
@@ -5,10 +5,7 @@ description: How to install and run this repository's pre-commit, husky, Prettie
 
 # Git Hooks & Local Checks
 
-This repository ships configuration for several automated checks that run against
-your changes. They are **configured** when you clone, but most of them are not
-**installed** until you run a setup command — so a fresh clone will happily let you
-commit code that the tooling would otherwise flag.
+This repository ships configuration for several automated checks that run against your changes. They are **configured** when you clone, but most of them are not **installed** until you run a setup command — so a fresh clone will happily let you commit code that the tooling would otherwise flag.
 
 This page covers the one-time setup and the manual commands you can run any time.
 
@@ -23,16 +20,13 @@ This page covers the one-time setup and the manual commands you can run any time
 | `.markdownlintignore` | [markdownlint-cli](https://github.com/igorshubovych/markdownlint-cli) | Paths excluded from Markdown linting |
 | `.editorconfig` | [EditorConfig](https://editorconfig.org/) | Editor-level whitespace/charset defaults (applied by your editor, no install step) |
 
-Open `.pre-commit-config.yaml` and the scripts in `.husky/` for the authoritative,
-up-to-date list of what actually runs — the configs are the source of truth, and
-they change more often than this page does.
+Open `.pre-commit-config.yaml` and the scripts in `.husky/` for the authoritative, up-to-date list of what actually runs — the configs are the source of truth, and they change more often than this page does.
 
 ## One-time setup
 
 ### 1. Install the pre-commit hooks
 
-`pre-commit` is a standalone tool; installing this repository's dependencies does
-not install it for you. Pick whichever channel suits your machine:
+`pre-commit` is a standalone tool; installing this repository's dependencies does not install it for you. Pick whichever channel suits your machine:
 
 ```bash
 # any one of these
@@ -47,20 +41,16 @@ Then, from the repository root, wire it into your local `.git/hooks`:
 pre-commit install
 ```
 
-From this point on, the hooks declared in `.pre-commit-config.yaml` run
-automatically against your **staged** files each time you `git commit`.
+From this point on, the hooks declared in `.pre-commit-config.yaml` run automatically against your **staged** files each time you `git commit`.
 
 > The first run downloads and caches each hook's environment, so expect it to be
 > noticeably slower than subsequent runs.
 
 ### 2. Enable the husky hooks
 
-The `.husky/` directory holds Git hook scripts. Husky works by pointing Git's
-`core.hooksPath` setting at that directory — until that setting exists in your
-local clone, the scripts in `.husky/` are inert.
+The `.husky/` directory holds Git hook scripts. Husky works by pointing Git's `core.hooksPath` setting at that directory — until that setting exists in your local clone, the scripts in `.husky/` are inert.
 
-If the project exposes an npm `prepare` script that runs husky, installing the
-Node dependencies is enough:
+If the project exposes an npm `prepare` script that runs husky, installing the Node dependencies is enough:
 
 ```bash
 npm install
@@ -89,8 +79,7 @@ git config --get core.hooksPath   # should print: .husky
 
 ## Running the checks manually
 
-You do not need to make a commit to exercise the checks. This is the fastest way to
-reproduce a CI failure locally.
+You do not need to make a commit to exercise the checks. This is the fastest way to reproduce a CI failure locally.
 
 ### pre-commit
 
@@ -113,8 +102,7 @@ pre-commit autoupdate
 
 ### Prettier
 
-`.prettierrc` and `.prettierignore` are picked up automatically when you run
-Prettier from the repository root. Prettier requires Node.js.
+`.prettierrc` and `.prettierignore` are picked up automatically when you run Prettier from the repository root. Prettier requires Node.js.
 
 ```bash
 # report files that are not formatted (non-zero exit if any are found)
@@ -139,9 +127,7 @@ npx markdownlint-cli '**/*.md'
 
 ## Skipping hooks
 
-Sometimes you need to land a commit without running the hooks — a work-in-progress
-commit on a scratch branch, or an emergency fix. Use this sparingly: whatever the
-hooks catch locally will usually be caught again in review or CI.
+Sometimes you need to land a commit without running the hooks — a work-in-progress commit on a scratch branch, or an emergency fix. Use this sparingly: whatever the hooks catch locally will usually be caught again in review or CI.
 
 ```bash
 # skip all Git hooks for a single commit (works for both pre-commit and husky)
@@ -153,9 +139,7 @@ SKIP=<hook-id>,<other-hook-id> git commit -m "..."
 
 ## Troubleshooting
 
-**`pre-commit: command not found` on commit.** The hook script was installed but the
-executable is not on your `PATH` — common with `pip install --user`. Reinstall via
-`pipx` or `brew`, or add the user script directory to your `PATH`.
+**`pre-commit: command not found` on commit.** The hook script was installed but the executable is not on your `PATH` — common with `pip install --user`. Reinstall via `pipx` or `brew`, or add the user script directory to your `PATH`.
 
 **Hooks don't run at all.** Confirm the installation actually happened:
 
@@ -164,16 +148,11 @@ ls .git/hooks/pre-commit          # pre-commit writes a shim here
 git config --get core.hooksPath   # husky sets this to .husky
 ```
 
-Note that if `core.hooksPath` is set, Git ignores `.git/hooks/` entirely — that is
-the usual reason a `pre-commit install` appears to have no effect.
+Note that if `core.hooksPath` is set, Git ignores `.git/hooks/` entirely — that is the usual reason a `pre-commit install` appears to have no effect.
 
-**A hook fails on files you didn't touch.** Formatters run over whatever they are
-given; if a hook was recently added, pre-existing files may fail on their first run.
-Raise it with a maintainer rather than reformatting unrelated files inside a
-feature branch.
+**A hook fails on files you didn't touch.** Formatters run over whatever they are given; if a hook was recently added, pre-existing files may fail on their first run. Raise it with a maintainer rather than reformatting unrelated files inside a feature branch.
 
-**Hook environments look stale after a config change.** Clear the cached
-environments and let pre-commit rebuild them:
+**Hook environments look stale after a config change.** Clear the cached environments and let pre-commit rebuild them:
 
 ```bash
 pre-commit clean


### PR DESCRIPTION
## What

Adds `docs/git-hooks.md`, a short contributor-facing page covering:

- which lint/format config files this repo ships,
- how to install the `pre-commit` hooks and the `.husky/` hooks,
- how to run each check manually (useful in CI-failure triage and before pushing),
- how to skip hooks deliberately when you need to.

Documentation-only change — no code, config, or workflow files touched.

## Why

The repository root contains `.pre-commit-config.yaml`, `.husky/`, `.prettierrc`, `.prettierignore`, and `.markdownlintignore`, which together imply contributors are expected to run local hooks. Nothing in the top-level tree explains the installation step, so a newcomer cloning the repo gets hooks that are configured but never installed, and only discovers the rules when CI (or a reviewer) complains.

## ⚠️ Please verify before merging

I wrote this from the repository's **file listing only** — I did not have the contents of the config files available, so I deliberately restricted the page to each tool's own documented usage and marked repo-specific details as unverified. Please confirm or correct the following:

1. **Which hooks `.pre-commit-config.yaml` actually declares.** The page currently says "see the file for the authoritative list" instead of enumerating them. If you'd like, replace that line with the real hook IDs and I'll fold them in.
2. **How `.husky/` hooks get installed here.** There is **no `package.json` at the repository root** in the file listing, so the usual husky bootstrap (`npm install` triggering a `prepare` script that runs `husky`) may not apply. I documented the manual fallback `git config core.hooksPath .husky` and flagged it as needing confirmation. If husky is installed from a nested project directory, that path should be named explicitly.
3. **Whether `pre-commit` and `.husky/` overlap.** If one of them already invokes Prettier/markdownlint, the "run it manually" commands should point at the single canonical entry point rather than the tools directly.
4. **The markdownlint CLI in use.** `.markdownlintignore` is read by `markdownlint-cli`; `markdownlint-cli2` uses a different ignore mechanism. I noted both and did not assert which one this repo uses.
5. **Preferred install channel for `pre-commit`** (pip vs. Homebrew vs. pipx) — I listed the upstream-documented options rather than picking one.
6. **Where this should live.** I added a new file under `docs/` rather than editing `CONTRIBUTING.md`, because I could not see the current contents of `CONTRIBUTING.md` and did not want to clobber it. A one-line link from `CONTRIBUTING.md` to `docs/git-hooks.md` would be the natural follow-up.

Any inline `> **Verify:**` callouts left in the page are meant to be resolved (edited or deleted) before merge — happy to take corrections and re-roll the file.

---
🤖 wtd fleet · `doc-writer` agent · item `bamr87/bamr87:write_docs:463dbf36c322`
<!-- wtd-fleet:bamr87/bamr87:write_docs:463dbf36c322 -->