### PR TITLE
fix(evolution): publish to the target repo, and stop discarding finished agents

### DIFF
--- a/.github/scripts/dash-gen/evolution.py
+++ b/.github/scripts/dash-gen/evolution.py
@@ -77,7 +77,7 @@ DEFAULTS: dict = {
     "label": "ai-evolution",           # created on demand in the target repo
     "max_targets": 6,                  # repos evolved per run; the rest are logged and dropped
     "max_parallel": 2,                 # concurrent Claude passes
-    "max_turns": 60,                   # per repo — one repo per job
+    "max_turns": 120,                  # per repo — one repo per job; above the 63 observed in run #1
     "skip_when_open_pr": True,         # one open evolution PR per repo at a time
     "signals": {"max_issues": 8, "max_prs": 5},
 }

--- a/.github/scripts/dash-gen/test_evolution.py
+++ b/.github/scripts/dash-gen/test_evolution.py
@@ -380,6 +380,35 @@ def test_workflow_contract() -> None:
           "needs.plan.outputs.branch_prefix" in str(pub["env"].get("PREFIX"))
           and "needs.plan.outputs.label" in str(pub["env"].get("LABEL")))
     check("a moved HEAD refuses to publish", "git rev-parse --abbrev-ref HEAD" in run and "exit 1" in run)
+    # The `Evolve` action derives its repository from `github.repository` (the
+    # hub) and revokes its own token inside the step, so it leaves the checkout
+    # pointing at bamr87/bamr87 with a dead credential. Run #1's `scripts` job
+    # pushed there and failed; a push that SUCCEEDED would have put a
+    # submodule's changes on the hub. The publish step must re-derive the
+    # remote from $NWO and refuse anything else. (bamr87/bamr87#214)
+    check("the publish remote is re-derived from $NWO, never the inherited origin",
+          'git remote set-url origin "$REMOTE"' in run and 'REMOTE="${SERVER}/${NWO}"' in run)
+    check("an auth header left by the agent step is cleared before pushing",
+          ".extraheader" in run)
+    check("a publish remote that is not $NWO refuses to push",
+          "git remote get-url origin" in run
+          and 'refusing to push' in run)
+    check("the push targets the explicit URL, not the remote name",
+          'git push -q "$REMOTE"' in run and "git push -q -u origin" not in run)
+
+    # A turn count that overshoots --max-turns fails the step even when the
+    # agent reported success, which skipped `Open draft PR` and discarded
+    # finished, billed work on run #1's README job.
+    # Tolerant lookup, unlike step(): a missing step must be reported as a
+    # failed check alongside the others, not abort the run before they print.
+    salv = next((s for s in evolve["steps"] if s.get("name") == "Salvage a successful overshoot"), {})
+    check("a successful result that overshot the turn cap is detected",
+          "steps.evolve.outcome == 'failure'" in str(salv.get("if"))
+          and ".subtype" in salv["run"] and ".is_error" in salv["run"])
+    check("a salvaged success still reaches the publish step",
+          "steps.salvage.outputs.succeeded == 'true'" in str(pub.get("if")))
+    check("max_turns is above the ceiling observed in run #1 (63 turns)",
+          int(fleet["evolution"]["max_turns"]) > 63)
     check("commits as the bot identity", "bamr87-bot" in run and "10567847+bamr87@users.noreply.github.com" in run)
     for pat in (fleet.get("dependencies") or {}).get("lockfile_patterns") or []:
         # The step greps the literal filename with only the dot escaped; re.escape

--- a/.github/workflows/repo-evolution.yml
+++ b/.github/workflows/repo-evolution.yml
@@ -140,7 +140,7 @@ jobs:
             echo "matrix=$(jq -c '{include: .include}' plan.json)"
             echo "count=$(jq -r '.count' plan.json)"
             echo "max_parallel=$(jq -r '.max_parallel // 2' plan.json)"
-            echo "max_turns=$(jq -r '.max_turns // 60' plan.json)"
+            echo "max_turns=$(jq -r '.max_turns // 120' plan.json)"
             echo "branch_prefix=$(jq -r '.branch_prefix // "ai-evolution"' plan.json)"
             echo "label=$(jq -r '.label // "ai-evolution"' plan.json)"
           } >> "$GITHUB_OUTPUT"
@@ -360,6 +360,37 @@ jobs:
             echo "::warning::${TIER}: Claude ran ($turns turn(s), \$$cost billed) and still failed — an agent/tooling failure, not auth."
           fi
 
+      # `claude-code-action` fails the step when the turn count OVERSHOOTS
+      # --max-turns even where the agent itself finished: run #1's README job
+      # died on "Claude reported a successful result after 63 turns, exceeding
+      # the configured maximum of 60", `Open draft PR` was skipped, and $2.85
+      # of completed work was thrown away. Raising max_turns makes that rarer,
+      # not impossible — the cap is a bound, and a bound can always be hit. The
+      # agent's own verdict is in the execution log, so read it and let the
+      # publish step run. `subtype == "success"` AND `is_error == false` is the
+      # agent saying it finished; a genuine turn exhaustion reports neither.
+      - name: Salvage a successful overshoot
+        id: salvage
+        if: ${{ !cancelled() && steps.evolve.outcome == 'failure' }}
+        env:
+          TIER: Repo evolution — ${{ matrix.name }}
+        run: |
+          log="${RUNNER_TEMP}/claude-execution-output.json"
+          ok=false
+          if [ -f "$log" ]; then
+            result=$(jq -c '[.. | objects | select(.type? == "result")] | last // empty' "$log" 2>/dev/null || true)
+            if [ -n "$result" ]; then
+              subtype=$(printf '%s' "$result" | jq -r '.subtype // ""')
+              is_error=$(printf '%s' "$result" | jq -r '.is_error // true')
+              turns=$(printf '%s' "$result" | jq -r '.num_turns // 0')
+              if [ "$subtype" = "success" ] && [ "$is_error" = "false" ]; then
+                ok=true
+                echo "::warning::${TIER}: the step failed but the agent reported success after ${turns} turn(s) — publishing its work rather than discarding it. Raise \`evolution.max_turns\` in _data/fleet.yml if this recurs."
+              fi
+            fi
+          fi
+          echo "succeeded=${ok}" >> "$GITHUB_OUTPUT"
+
       - name: Report dry run
         if: ${{ inputs.dry_run == true }}
         run: |
@@ -382,7 +413,7 @@ jobs:
       # the TARGET repo with the brief's marker as its first line.
       - name: Open draft PR
         id: publish
-        if: ${{ inputs.dry_run != true }}
+        if: ${{ !cancelled() && inputs.dry_run != true && (steps.evolve.outcome == 'success' || steps.salvage.outputs.succeeded == 'true') }}
         env:
           GH_TOKEN: ${{ secrets.FLEET_TOKEN || secrets.FANOUT_TOKEN }}
           PREFIX: ${{ needs.plan.outputs.branch_prefix }}
@@ -418,6 +449,28 @@ jobs:
           fi
 
           BR="${PREFIX}/$(date -u +%Y%m%d)-${GITHUB_RUN_ID}"
+
+          # NEVER trust the inherited `origin`. `claude-code-action` derives its
+          # repository from `github.repository` (the HUB, not the checkout) and
+          # leaves the tree's remote/credential state pointing there with an
+          # installation token it has already revoked. In run #1 the `scripts`
+          # job checked out bamr87/scripts and then pushed to
+          # bamr87/bamr87.git, dying on `Invalid username or token` 0.5s after
+          # the action's own `Revoke app token` step. A push that FAILED is the
+          # lucky outcome; one that succeeded would have put a submodule's
+          # changes on the hub. Re-assert the remote from $NWO, drop any auth
+          # header the action left behind, then assert the invariant — the same
+          # shape as the moved-HEAD guard above. See bamr87/bamr87#214.
+          SERVER="${GITHUB_SERVER_URL:-https://github.com}"
+          REMOTE="${SERVER}/${NWO}"
+          git remote set-url origin "$REMOTE"
+          git config --unset-all "http.${SERVER}/.extraheader" 2>/dev/null || true
+          actual="$(git remote get-url origin)"
+          if [ "$actual" != "$REMOTE" ]; then
+            echo "::error::${NAME}: publish remote is '${actual}', expected '${REMOTE}' — refusing to push."
+            exit 1
+          fi
+
           git config credential.helper '!gh auth git-credential'
           git config user.name  "bamr87-bot"
           git config user.email "10567847+bamr87@users.noreply.github.com"
@@ -425,7 +478,9 @@ jobs:
           git add -A
           git commit -q -m "chore(evolve): weekly AI improvement pass" \
             -m "Documentation, clarity, and functionality pass from the bamr87/bamr87 repo-evolution loop (run ${GITHUB_RUN_ID}). Draft for human review; nothing merges automatically."
-          git push -q -u origin "$BR"
+          # Explicit URL, not the remote name: even a re-asserted `origin` is
+          # only as good as the config the previous step left readable.
+          git push -q "$REMOTE" "HEAD:refs/heads/${BR}"
 
           # The agent's final message is the reviewer-facing body. The
           # execution log is the same file the failure classifier reads.

--- a/_data/fleet.yml
+++ b/_data/fleet.yml
@@ -258,7 +258,16 @@ evolution:
   # the listed issues/PRs that touch the change, edit, verify with the repo's
   # own lint/tests, report. Wired into `--max-turns` through the plan so this
   # is the only place the number is stated; test_evolution.py asserts the wiring.
-  max_turns: 60
+  #
+  # 120, not 60. Run #1 (2026-08-31) measured what that program actually costs:
+  # scripts 46 turns, cv-builder-pro 61, README 63. A cap of 60 sat at the
+  # MEDIAN of real demand, so two of three targets were billed in full
+  # ($3.51 + $2.85) and produced no pull request — one exhausted at the cap,
+  # one finished and had its result rejected for overshooting it. Set above the
+  # observed ceiling of 63 with headroom for a repo larger than any of the
+  # three, not at it. See bamr87/bamr87#214; `Salvage a successful overshoot`
+  # in repo-evolution.yml is the backstop for the day this bound is hit anyway.
+  max_turns: 120
 
   # How much of the triage snapshot each brief quotes. The rest is a link.
   signals:

--- a/docs/EVOLUTION.md
+++ b/docs/EVOLUTION.md
@@ -71,6 +71,10 @@ priority order — documentation → clarity → functionality — verifies with
 
 Then the workflow — and only the workflow — commits as `bamr87-bot`, pushes `ai-evolution/<yyyymmdd>-<run id>`, and opens a **draft** PR in the target repo with the brief's marker as the first line of the body, the agent's report, and a link back to the run. It refuses to publish if the agent moved `HEAD` off the base branch, and it drops any lockfile a verify step produced ([always-latest policy](DEPENDENCIES.md)). No changes → no branch, no PR, one summary line.
 
+**The publish step re-derives its own remote and never trusts `origin`.** `claude-code-action` resolves its repository from `github.repository` — the *hub*, not the checkout — and revokes its own installation token before the step ends, so it leaves the tree pointing at `bamr87/bamr87` with a dead credential. Run #1's `scripts` job checked out `bamr87/scripts` and pushed to `bamr87/bamr87.git`; the push failed on `Invalid username or token`, which was the lucky outcome — one that *succeeded* would have put a submodule's changes on the hub. So the step sets `origin` from `$NWO`, clears any `http.<server>/.extraheader` the agent step left behind, hard-fails with a named `::error::` if the remote is anything but `$NWO`, and pushes to the explicit URL rather than the remote name. `test_evolution.py` asserts all four ([#214](https://github.com/bamr87/bamr87/issues/214)).
+
+**A finished agent is never thrown away for overshooting the cap.** `claude-code-action` fails the step when the turn count exceeds `--max-turns` *even when the agent reported success* — run #1's `README` job was billed $2.85 for completed work that `Open draft PR` then never saw, because a failed step skips the rest of the job. The `Salvage a successful overshoot` step reads the agent's own verdict out of `claude-execution-output.json` (`subtype == "success"` **and** `is_error == false`; a genuine turn exhaustion reports neither), warns, and lets the publish step run anyway. Raising `max_turns` makes the case rarer; only this makes it non-destructive.
+
 ### Lanes — why it does not collide with the other loops
 
 The brief *tells* the agent about the repo's failing workflows and open issues and PRs, and the prompt *forbids* acting on them: a failing workflow belongs to the fleet doctor, an open issue to the issue pipeline, an open PR to whoever opened it. The signals are context — where the repo hurts — not work. What is left is exactly this loop's lane: the improvements nobody filed.
@@ -133,7 +137,7 @@ All in [`_data/fleet.yml`](../_data/fleet.yml), read by the planner and wired in
 | `evolution.branch_prefix` / `marker` / `label` | `ai-evolution` / `repo-evolution` / `ai-evolution` | how a pass is recognised and labelled |
 | `evolution.max_targets` | `6` | repos per run |
 | `evolution.max_parallel` | `2` | concurrent agents (the Claude loops share one OAuth account) |
-| `evolution.max_turns` | `60` | per repo — orient, read, edit, verify, report |
+| `evolution.max_turns` | `120` | per repo — orient, read, edit, verify, report. Run #1 (2026-08-31) measured that program at **46 / 61 / 63** turns (`scripts` / `cv-builder-pro` / `README`); the old cap of `60` sat at the median of real demand, so two of three targets were billed in full and produced no PR. Set above the observed ceiling, not at it. |
 | `evolution.signals.max_issues` / `max_prs` | `8` / `5` | how much of the triage snapshot a brief quotes |
 
 ## Tokens


### PR DESCRIPTION
<!-- issue-pipeline tier="2" key="bamr87/bamr87#214" -->

Closes #214

`repo-evolution.yml` has never been green. Run #1 failed three of four jobs with three unrelated causes, and two of them threw away work that had already been billed — **$6.36 of Claude turns for zero pull requests**. All three are fixed here.

## What changed

One line per acceptance criterion from the issue.

| Criterion | Change |
| --- | --- |
| `Open draft PR` pushes to an explicit URL derived from `$NWO`, clearing the inherited `extraheader` | `repo-evolution.yml:452-471` — `SERVER`/`REMOTE` derived from `$NWO`, `git remote set-url origin "$REMOTE"`, `git config --unset-all "http.${SERVER}/.extraheader"`, and the push is `git push -q "$REMOTE" "HEAD:refs/heads/${BR}"` rather than `git push -q -u origin "$BR"`. |
| It hard-fails with a named `::error::` when the remote is not `$NWO`, mirroring the wrong-base guard | Same block: `actual="$(git remote get-url origin)"` → `::error::${NAME}: publish remote is '…', expected '…' — refusing to push.` → `exit 1`. Deliberately placed *after* the re-assertion, so it is the invariant check, not the repair. |
| `evolution.max_turns` raised above the observed ceiling, with the measured counts as the stated basis | `_data/fleet.yml` `60 → 120`, with a comment citing 46 / 61 / 63 from run #1 and why the median was the wrong place to put a cap. Mirrored in `evolution.py`'s `DEFAULTS` fallback and the workflow's `jq '.max_turns // 120'` fallback so all three fallbacks agree. |
| "Succeeded but overshot" no longer discards finished work | New `Salvage a successful overshoot` step (`repo-evolution.yml:363-392`): on `steps.evolve.outcome == 'failure'` it reads the last `result` record from `${RUNNER_TEMP}/claude-execution-output.json` and sets `succeeded=true` only when `subtype == "success"` **and** `is_error == false`. `Open draft PR`'s `if:` gains `(steps.evolve.outcome == 'success' \|\| steps.salvage.outputs.succeeded == 'true')`. |
| New test asserting the remote guard, failing before and passing after | `test_evolution.py` gains **7** checks in `test_workflow_contract()`. |
| `docs/EVOLUTION.md` records the turn-budget basis and the publish-path remote requirement | Two new paragraphs after the publish description, plus the `max_turns` row in the configuration table. |

## Why

The three causes are independent, and the second and third are the ones that make this expensive rather than merely red:

1. **Wrong remote.** `claude-code-action` derives its repository from `github.repository` — the **hub**, not the checkout — and its own `Revoke app token` step runs 0.5s before the push. The `scripts` job checked out `bamr87/scripts` (the log shows `git remote add origin https://github.com/bamr87/scripts`) and pushed to `bamr87/bamr87.git`. **The failure was the lucky outcome**: a push that *succeeded* would have put a submodule's changes on the hub. `persist-credentials: false` on the checkout means the publish step was always going to configure its own credentials — it just never re-asserted the *remote* to go with them.
2. **Discarded success.** The `README` job returned `subtype: success` after 63 turns and the action failed the step *post hoc* for the turn count. A failed step skips the rest of the job, so `Open draft PR` never ran. Raising the cap makes this rarer, not impossible — a bound can always be hit — so the salvage step is the actual fix and the raise is the mitigation.
3. **Cap at the median.** 46 / 61 / 63 observed against a cap of 60 is a ~50% failure rate by construction.

## Verification

Every command run locally on this branch.

**The new checks fail before the fix.** With only `repo-evolution.yml` and `_data/fleet.yml` reverted to `main` (`git stash push` on those two paths, test file kept):

```console
$ python3 .github/scripts/dash-gen/test_evolution.py
  FAIL  the publish remote is re-derived from $NWO, never the inherited origin
  FAIL  an auth header left by the agent step is cleared before pushing
  FAIL  a publish remote that is not $NWO refuses to push
  FAIL  the push targets the explicit URL, not the remote name
  FAIL  a successful result that overshot the turn cap is detected
  FAIL  a salvaged success still reaches the publish step
  FAIL  max_turns is above the ceiling observed in run #1 (63 turns)
FAILED (7/133)
```

**And pass after it:**

```console
$ python3 .github/scripts/dash-gen/test_evolution.py
OK (133 checks)          # 126 on main + the 7 above
```

> `pytest` is not installed on this runner, and it is not how this suite reports: `test_evolution.py` is a dependency-light script whose pass/fail signal is its **exit code** (`python3 test_evolution.py`), which is exactly how `tools/run-all-tests.sh:112` invokes it. Under `pytest` the `test_*` functions would collect and return without asserting, so the numbers above are from the documented invocation. Nothing about the file's harness was changed.

**The rest of the control plane is unaffected:**

```console
$ python3 .github/scripts/dash-gen/test_fleet_pulse_doctor.py   → OK (20 checks)
$ python3 .github/scripts/dash-gen/test_remediation.py          → OK (38 checks)
$ python3 .github/scripts/dash-gen/test_issue_pipeline.py       → All checks passed.
$ python3 .github/scripts/dash-gen/test_harness.py              → OK — harness fixture tests
$ python3 tools/schema_lint.py check .                          → PASS: 0 error(s), 3 warning(s)
```

The three `schema_lint` warnings are the gitignored `issue-workorder-t{1,2,3}.md` files this pipeline run itself produced; they are present on `main` too and are not touched here.

**Both edited shell blocks are shellcheck-clean** (extracted from the YAML, `--severity=warning`):

```console
--- Salvage a successful overshoot: exit 0   (clean)
--- Open draft PR: exit 0                    (clean)
```

**The new number flows through the planner** (offline, no network):

```console
$ python3 -c "…ev.build_plan(registry, ev.load_config('_data/fleet.yml'), …)"
max_turns: 120 | count: 3 | targets: ['cv-builder-pro', 'README', 'scripts']
```

## Risk / blast radius

- **The remote re-assertion is the only behavioural change to a green path**, and it is a no-op when `origin` is already correct: `set-url` to the value it already holds, an `--unset-all` guarded with `|| true`, then an equality check that passes. `GITHUB_SERVER_URL` is always set on GitHub-hosted runners; the `:-https://github.com` default covers act/local. The `.git` suffix is not appended — `actions/checkout` writes the bare form, and `git push` accepts either.
- **Pushing to an explicit URL drops the upstream-tracking `-u`.** Nothing downstream reads it: the PR is opened with `gh pr create --head "$BR"`, and `git diff --stat "${BASE}...HEAD"` in the summary is local-only. Checked both call sites.
- **The salvage step cannot turn a real failure into a PR.** It requires `subtype == "success"` *and* `is_error == false` from the agent's own final `result` record. Turn exhaustion (`cv-builder-pro`) reports neither, and a rejected credential produces no `result` record at all — so both remain hard failures, and `Diagnose Claude failure` still classifies them first. If the log is missing or unparseable the default is `false`.
- **A salvaged job still reports red**, because the `Evolve` step genuinely failed. That is intentional: the work is published *and* the overshoot stays visible. `continue-on-error` would have hidden it and is forbidden by fleet policy.
- **`Report dry run` is untouched** and still skipped when `Evolve` fails — pre-existing behaviour, out of scope here.
- **Raising `max_turns` to 120 raises the per-repo cost ceiling.** With `max_targets: 6` the worst case roughly doubles. This is the intended trade: run #1 spent $9.25 for nothing, and a target that finishes at 63 turns costs the same 63 turns whether the cap is 60 or 120.

## Not done

One acceptance criterion is deliberately left for a human, and it is the one that proves the fix end to end:

> A `workflow_dispatch` run with `target: scripts` and `dry_run: false` opens a draft PR in `bamr87/scripts` — or reports "no changes" — and the run is green.

That requires dispatching this branch's workflow, which spends Claude budget and opens a pull request in another repository. Run it from the Actions tab (**🌿 Repo Evolution** → *Run workflow*, branch `agent/issue-214`, `target: scripts`) before marking this ready for review. A `dry_run: true` pass on the same branch exercises the agent and the plan but **not** the publish path, so it does not substitute for it.

This issue is `size:xl` / **`assisted`** — tier 3 will not mark it ready for review.
