### PR TITLE
fix(vendor): fetch upstream through the contents API, not raw.githubusercontent

### DIFF
--- a/.github/scripts/dash-gen/schema_vendor.py
+++ b/.github/scripts/dash-gen/schema_vendor.py
@@ -39,6 +39,7 @@ import os
 import re
 import sys
 import urllib.error
+import urllib.parse
 import urllib.request
 from dataclasses import dataclass, field
 from pathlib import Path
@@ -116,20 +117,42 @@ def digests(blob: bytes) -> tuple[str, str]:
 # --------------------------------------------------------------------------- #
 # upstream access
 # --------------------------------------------------------------------------- #
-def _raw_url(nwo: str, ref: str, path: str) -> str:
-    return f"https://raw.githubusercontent.com/{nwo}/{ref}/{path}"
+def _authorize(req: urllib.request.Request) -> urllib.request.Request:
+    token = os.environ.get("GH_TOKEN") or os.environ.get("GITHUB_TOKEN")
+    if token:
+        req.add_header("Authorization", f"Bearer {token}")
+    return req
+
+
+def content_request(nwo: str, ref: str, path: str) -> urllib.request.Request:
+    """A request for one file's bytes, through the Contents API.
+
+    NOT raw.githubusercontent.com, and the reason is a trap worth naming:
+    that host 404s — not 401s — when handed an `Authorization: Bearer` header
+    it does not accept, which the Actions `GITHUB_TOKEN` is. The workflow always
+    sets GH_TOKEN, so the first live run of this loop reported a PUBLIC file as
+    "upstream unreachable", warned, and stopped. A weekly job that can never
+    run is exactly the failure this loop exists to catch, so it must not be the
+    shape of the loop itself.
+
+    `api.github.com/.../contents` with the raw media type accepts a Bearer
+    token and works without one, which also makes a private upstream readable
+    rather than indistinguishable from a deleted one.
+    """
+    url = (f"https://api.github.com/repos/{nwo}/contents/"
+           f"{urllib.parse.quote(path)}?ref={urllib.parse.quote(ref)}")
+    return _authorize(urllib.request.Request(url, headers={
+        "Accept": "application/vnd.github.raw",
+        "User-Agent": "bamr87-dash/schema-vendor",
+    }))
 
 
 def http_fetcher(nwo: str = UPSTREAM_NWO, ref: str = UPSTREAM_REF, timeout: int = 20):
-    """Return fetch(path) -> bytes, reading raw files from GitHub."""
+    """Return fetch(path) -> bytes, reading file contents from GitHub."""
 
     def fetch(path: str) -> bytes:
-        req = urllib.request.Request(_raw_url(nwo, ref, path),
-                                     headers={"User-Agent": "bamr87-dash/schema-vendor"})
-        token = os.environ.get("GH_TOKEN") or os.environ.get("GITHUB_TOKEN")
-        if token:
-            req.add_header("Authorization", f"Bearer {token}")
-        with urllib.request.urlopen(req, timeout=timeout) as resp:
+        with urllib.request.urlopen(content_request(nwo, ref, path),
+                                    timeout=timeout) as resp:
             return resp.read()
 
     return fetch
@@ -142,13 +165,10 @@ def head_commit(nwo: str = UPSTREAM_NWO, ref: str = UPSTREAM_REF,
     Provenance only: a missing sha degrades the VERSION stamp, never the
     comparison, which is content-addressed and needs no commit at all.
     """
-    req = urllib.request.Request(
+    req = _authorize(urllib.request.Request(
         f"https://api.github.com/repos/{nwo}/commits/{ref}",
         headers={"Accept": "application/vnd.github+json",
-                 "User-Agent": "bamr87-dash/schema-vendor"})
-    token = os.environ.get("GH_TOKEN") or os.environ.get("GITHUB_TOKEN")
-    if token:
-        req.add_header("Authorization", f"Bearer {token}")
+                 "User-Agent": "bamr87-dash/schema-vendor"}))
     try:
         with urllib.request.urlopen(req, timeout=timeout) as resp:
             return (json.load(resp).get("sha") or "")[:7]

--- a/.github/scripts/dash-gen/test_schema_vendor.py
+++ b/.github/scripts/dash-gen/test_schema_vendor.py
@@ -16,6 +16,7 @@ only PyYAML and runs on a bare interpreter:
 
 from __future__ import annotations
 
+import os
 import shutil
 import sys
 import tempfile
@@ -176,6 +177,42 @@ def main() -> int:
     sv.apply_plan(root, plan, fetch, today="2026-09-03")
     check("nothing to re-vendor leaves VERSION alone",
           (root / sv.VERSION_FILE).read_text() == before)
+
+    # --- how upstream is actually fetched -----------------------------------
+    # Regression guard. The first live run of this loop reported a PUBLIC file
+    # as "upstream unreachable": raw.githubusercontent.com 404s — not 401s —
+    # when handed an Authorization header it does not accept, and the workflow
+    # always sets GH_TOKEN. A weekly job that can never run is the exact failure
+    # this loop exists to catch, so the transport is pinned here.
+    print("fetch transport:")
+    saved = {k: os.environ.pop(k, None) for k in ("GH_TOKEN", "GITHUB_TOKEN")}
+    try:
+        req = sv.content_request("owner/repo", "main", "tools/schema_lint.py")
+        check("never fetches from raw.githubusercontent.com",
+              "raw.githubusercontent.com" not in req.full_url)
+        check("uses the contents API", req.full_url.startswith(
+            "https://api.github.com/repos/owner/repo/contents/"))
+        check("asks for the raw media type",
+              req.get_header("Accept") == "application/vnd.github.raw")
+        check("pins the ref", "ref=main" in req.full_url)
+        # Slashes stay slashes — they are real path segments to the API — but
+        # anything that would break the URL is escaped.
+        check("keeps path separators intact",
+              req.full_url.endswith("/contents/tools/schema_lint.py?ref=main"))
+        check("escapes characters that would break the URL",
+              "a%20b%23c" in sv.content_request("o/r", "main", "a b#c").full_url)
+        check("sends no Authorization when there is no token",
+              req.get_header("Authorization") is None)
+
+        os.environ["GH_TOKEN"] = "t0ken"
+        req = sv.content_request("owner/repo", "main", "DISTRIBUTION.yml")
+        check("sends a Bearer token when one is present",
+              req.get_header("Authorization") == "Bearer t0ken")
+    finally:
+        os.environ.pop("GH_TOKEN", None)
+        for k, v in saved.items():
+            if v is not None:
+                os.environ[k] = v
 
     # --- normalization parity with upstream's schema_dist -------------------
     print("normalization:")


### PR DESCRIPTION
## Description

Follow-up to #226, found by running the merged loop for real against the now-merged upstream. **It reported a public file as "upstream unreachable" and stopped.**

`raw.githubusercontent.com` answers **404, not 401**, when handed an `Authorization: Bearer` header it does not accept — and the Actions `GITHUB_TOKEN` is one it does not accept. `schema-vendor.yml` always sets `GH_TOKEN`, so the fetcher always attached that header, so every weekly run would have read a 404 as "upstream is gone", emitted a warning annotation, and exited green without doing its job.

Reproduced directly against merged upstream:

| request | result |
| --- | --- |
| `raw.githubusercontent`, no auth | 200, 1889 bytes |
| `raw.githubusercontent`, + `Bearer` | **404** |
| contents API, raw media type, no auth | 200 |
| contents API, raw media type, + `Bearer` | 200 |

A loop that can never run is the exact failure this loop was written to catch, so it must not be the shape of the loop itself.

Fetching moves to `api.github.com/repos/{nwo}/contents/{path}?ref=` with `Accept: application/vnd.github.raw`, which accepts a Bearer token and works without one — and as a side effect makes a **private** upstream readable rather than indistinguishable from a deleted one. `head_commit()` already used the API; both now share one `_authorize()` helper.

## Related Issues

- Follow-up to #226 (no issue filed — found by running the merged code)

## Type Of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Maintenance or refactor
- [x] Test improvement

## Verification

- [x] **Reproduced the original failure, then the fix** — the table above, run against `bamr87/SCHEMA@93a42bc` from this checkout
- [x] **Live end-to-end** — `dash vendor` now reads the manifest and reports all three vendored copies current (linter byte-identical, both documents adapted-but-unchanged), with the `VERSION` stamp behind and correctly **non-actionable**, exit 0
- [x] **Tests pass** — 8 new assertions pin the transport (host, media type, ref, path escaping, and the header's presence *and* absence); full dash-gen suite green
- [x] **Lint/type checks pass** — drift gate ✅ No drift; `actionlint` clean on all 22 workflows; `shellcheck --severity=warning` clean on `fanout.sh`

## Notes For Reviewers

- The transport is pinned by test precisely because the failure was **silent**: green workflow, a warning annotation nobody reads, and no drift ever reported. That is the same shape as the truncated `gap-not-deployable` finding #226 removed — a check that cannot fire reads as coverage.
- Path separators are deliberately *not* percent-encoded (they are real path segments to the API); only characters that would break the URL are, and both halves are asserted.
- The branch was restarted from `main` after #226 merged, so this PR carries exactly one commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01B8pdBJkNs7RD8VHRMbR4oH

---
_Generated by [Claude Code](https://claude.ai/code/session_01B8pdBJkNs7RD8VHRMbR4oH)_