### PR TITLE
docs: add repository-orientation guide distinguishing the profile README from the monorepo

### DIFF
--- a/docs/repository-orientation.md
+++ b/docs/repository-orientation.md
@@ -13,9 +13,7 @@ updated: 2026-09-03
    <https://github.com/bamr87>. That file is a bio: background, technical stack,
    professional experience, and consulting services.
 2. **It is also a monorepo.** Behind the profile README sits a working codebase —
-   a static site, shared data and assets, submodules pointing at other projects,
-   schema and catalog documentation, and a fair amount of tooling and automation
-   configuration.
+a static site, shared data and assets, submodules pointing at other projects, schema and catalog documentation, and a fair amount of tooling and automation configuration.
 
 If you arrived expecting only a bio, this page is the map of everything else.
 
@@ -86,28 +84,22 @@ A reasonable reading order:
 1. **[`CONTRIBUTING.md`](../CONTRIBUTING.md)** — start here for the contribution
    workflow and any expectations about branches, commits, and review.
 2. **[`SUBMODULES.md`](../SUBMODULES.md)** — this repository uses git submodules
-   (`.gitmodules`), so a plain `git clone` will leave those directories empty.
-   Read this before wondering why something looks missing.
+(`.gitmodules`), so a plain `git clone` will leave those directories empty. Read this before wondering why something looks missing.
 3. **[`CATALOG.md`](../CATALOG.md)** — an index of what lives where.
 4. **[`SCHEMA.md`](../SCHEMA.md)** — if you are touching anything under `_data/`
    or otherwise structured, the schema is documented here.
 
 ## Building and running
 
-This page deliberately does **not** list build, serve, or test commands, because
-they have not been verified against the repository's actual configuration. The
-authoritative sources are:
+This page deliberately does **not** list build, serve, or test commands, because they have not been verified against the repository's actual configuration. The authoritative sources are:
 
 - `Gemfile` and `Rakefile` for Ruby-based tasks,
 - `docker-compose.yml` and `.devcontainer/` for containerised setups,
 - `.github/` for whatever CI runs on pull requests,
 - `CONTRIBUTING.md` for the maintainer's own instructions.
 
-If you work out the canonical local-development commands, adding them here is a
-welcome contribution.
+If you work out the canonical local-development commands, adding them here is a welcome contribution.
 
 ## A note on editing the profile README
 
-[`README.md`](../README.md) is public-facing on the GitHub account page. Changes
-to it are visible to anyone who visits <https://github.com/bamr87>, so treat
-edits there with more care than edits to files under `docs/`.
+[`README.md`](../README.md) is public-facing on the GitHub account page. Changes to it are visible to anyone who visits <https://github.com/bamr87>, so treat edits there with more care than edits to files under `docs/`.

--- a/docs/repository-orientation.md
+++ b/docs/repository-orientation.md
@@ -1,0 +1,113 @@
+---
+title: Repository Orientation
+author: Amr Abdel-Motaleb
+updated: 2026-09-03
+---
+
+# About this repository
+
+`bamr87/bamr87` does two jobs at once, which can be confusing on first visit.
+
+1. **It is a GitHub profile repository.** Because the repository name matches the
+   account name, GitHub renders [`README.md`](../README.md) at the top of
+   <https://github.com/bamr87>. That file is a bio: background, technical stack,
+   professional experience, and consulting services.
+2. **It is also a monorepo.** Behind the profile README sits a working codebase —
+   a static site, shared data and assets, submodules pointing at other projects,
+   schema and catalog documentation, and a fair amount of tooling and automation
+   configuration.
+
+If you arrived expecting only a bio, this page is the map of everything else.
+
+## Directory map
+
+Every entry below exists at the top level of the default branch (`main`).
+
+### Site and content
+
+| Path | What it is |
+| --- | --- |
+| [`index.md`](../index.md) | Site entry page. |
+| `pages/` | Additional site pages. |
+| `_data/` | Structured data consumed by the site. |
+| `assets/` | Images, styles, and other static assets. |
+| `_config.yml` | Primary site configuration. |
+| `_config_dev.yml` | Configuration overrides for local development. |
+| `Gemfile` | Ruby dependencies for the site build. |
+| `Rakefile` | Rake tasks for the repository. |
+
+> The combination of `_config.yml`, `_data/`, a `Gemfile`, and YAML front matter
+> in the markdown files is the conventional shape of a **Jekyll** site. Treat that
+> as a strong hint rather than a confirmed fact until you have read `_config.yml`.
+
+### Documentation
+
+| Path | What it covers |
+| --- | --- |
+| [`README.md`](../README.md) | The profile README rendered on the GitHub account page. |
+| [`CONTRIBUTING.md`](../CONTRIBUTING.md) | How to contribute to this repository. |
+| [`SUBMODULES.md`](../SUBMODULES.md) | How the git submodules in this repo are organised and used. |
+| [`SCHEMA.md`](../SCHEMA.md) | Schema documentation for the repository's structured data. |
+| [`CATALOG.md`](../CATALOG.md) | Catalog of the repository's contents. |
+| [`AGENTS.md`](../AGENTS.md) | Guidance for automated agents working in this repo. |
+| [`CLAUDE.md`](../CLAUDE.md) | Claude-specific working notes. |
+| `docs/` | Longer-form documentation, including this page. |
+| `diagrams/` | Diagram sources and/or rendered diagrams. |
+| `specs/` | Specifications. |
+| `_reports/` | Generated reports. |
+
+### Projects, templates, and tooling
+
+| Path | What it is |
+| --- | --- |
+| `projects/` | Project directories tracked by this monorepo. |
+| `templates/` | Reusable templates. |
+| `tools/` | Repository tooling and scripts. |
+| `.gitmodules` | Submodule definitions — see [`SUBMODULES.md`](../SUBMODULES.md). |
+
+### Environment and automation configuration
+
+| Path | Purpose |
+| --- | --- |
+| `.devcontainer/` | Dev container definition for reproducible environments. |
+| `docker-compose.yml` | Container service definitions. |
+| `.github/` | GitHub configuration, including any workflows. |
+| `.vscode/`, `home.code-workspace` | Editor configuration and workspace file. |
+| `.husky/`, `.pre-commit-config.yaml` | Git hook configuration. |
+| `.prettierrc`, `.prettierignore`, `.markdownlintignore`, `.editorconfig` | Formatting and lint configuration. |
+| `.env.example` | Template for local environment variables — copy, do not commit the result. |
+| `.zshrc`, `.zprofile`, `.gitconfig` | Shell and git dotfiles tracked in the repo. |
+| `fleet.manifest.yml`, `.mcp.json`, `.claude/` | Agent and automation configuration. |
+
+## Getting oriented as a newcomer
+
+A reasonable reading order:
+
+1. **[`CONTRIBUTING.md`](../CONTRIBUTING.md)** — start here for the contribution
+   workflow and any expectations about branches, commits, and review.
+2. **[`SUBMODULES.md`](../SUBMODULES.md)** — this repository uses git submodules
+   (`.gitmodules`), so a plain `git clone` will leave those directories empty.
+   Read this before wondering why something looks missing.
+3. **[`CATALOG.md`](../CATALOG.md)** — an index of what lives where.
+4. **[`SCHEMA.md`](../SCHEMA.md)** — if you are touching anything under `_data/`
+   or otherwise structured, the schema is documented here.
+
+## Building and running
+
+This page deliberately does **not** list build, serve, or test commands, because
+they have not been verified against the repository's actual configuration. The
+authoritative sources are:
+
+- `Gemfile` and `Rakefile` for Ruby-based tasks,
+- `docker-compose.yml` and `.devcontainer/` for containerised setups,
+- `.github/` for whatever CI runs on pull requests,
+- `CONTRIBUTING.md` for the maintainer's own instructions.
+
+If you work out the canonical local-development commands, adding them here is a
+welcome contribution.
+
+## A note on editing the profile README
+
+[`README.md`](../README.md) is public-facing on the GitHub account page. Changes
+to it are visible to anyone who visits <https://github.com/bamr87>, so treat
+edits there with more care than edits to files under `docs/`.


### PR DESCRIPTION
## What this does

Adds a single new documentation file, `docs/repository-orientation.md`, that answers the question a newcomer asks on landing in `bamr87/bamr87`: *is this just a GitHub profile README, or is it a working repository?*

The page contains:

- a short explanation that `bamr87/bamr87` serves double duty (special profile repo **and** monorepo),
- a map of every top-level entry in the repository, grouped by purpose,
- links onward to `CONTRIBUTING.md`, `SUBMODULES.md`, `SCHEMA.md`, `CATALOG.md`, and `AGENTS.md`.

## Why a new file instead of editing README.md directly

The task asked for a section inside `README.md`. I deliberately did **not** edit `README.md`, for two reasons:

1. **The README I was given was truncated** (it cut off mid-sentence in the "Cloud & Full-Stack Development" bullet list). Producing a "full file content" replacement would have meant reconstructing — i.e. inventing — everything below that point. That is a destructive edit I am not willing to guess at.
2. For the same reason I **cannot confirm that an orientation section doesn't already exist** further down the README. If it does, this PR should be closed or reduced to a link.

**Suggested follow-up for a human:** open `README.md`, confirm there is no existing "About this repository" section, and if not, add a one-line pointer near the top — for example:

```markdown
> New here and wondering what's in this repo (not just who I am)? See [docs/repository-orientation.md](docs/repository-orientation.md).
```

Or paste the body of the new file in as a section. Either way the content is written to work in both places.

## What I verified vs. what needs a human check

**Verified** — every path named in the new doc comes from the top-level file listing supplied to me: `.claude/`, `.devcontainer/`, `.github/`, `.husky/`, `.vscode/`, `AGENTS.md`, `CATALOG.md`, `CLAUDE.md`, `CONTRIBUTING.md`, `Gemfile`, `README.md`, `Rakefile`, `SCHEMA.md`, `SUBMODULES.md`, `_config.yml`, `_config_dev.yml`, `_data/`, `_reports/`, `assets/`, `diagrams/`, `docker-compose.yml`, `docs/`, `fleet.manifest.yml`, `home.code-workspace`, `index.md`, `pages/`, `projects/`, `specs/`, `templates/`, `tools/`, `.gitmodules`, `.mcp.json`, `.pre-commit-config.yaml`, `.prettierrc`, `.editorconfig`, `.env.example`, `.zshrc`, `.zprofile`, `.gitconfig`.

**Not verified — please check before merging:**

- **No build/run/test commands are documented.** I have not read `Gemfile`, `Rakefile`, `docker-compose.yml`, `_config.yml`, or `.github/workflows/`, so I did not write any `bundle`, `rake`, `docker compose`, or `jekyll` invocations. The doc says "see these files" rather than asserting a command. Adding real, tested commands is the obvious next improvement.
- **The "Jekyll" characterisation is inferred**, not read: `_config.yml` + `_config_dev.yml` + `Gemfile` + `_data/` + `index.md` + front matter in `README.md` are strong conventional signals, but I have not opened `_config.yml` to confirm. I hedged the wording accordingly.
- **Directory purposes are inferred from names** (`diagrams/`, `projects/`, `templates/`, `specs/`, `tools/`, `pages/`, `assets/`, `_reports/`). I described them tentatively; correct any I got wrong.
- **Front matter:** I gave the new file a minimal YAML front matter block (`title`, `author`, `updated`) mirroring the style of `README.md`, on the assumption that markdown in this repo is rendered by the site. If `docs/` is excluded from the build or uses different keys, adjust or drop the block.
- **`fleet.manifest.yml` / `.mcp.json` / `AGENTS.md` / `CLAUDE.md`** are described only as "agent and automation configuration" — I have not read them and made no claims about which tools consume them.

Only documentation files are touched by this PR.

---
🤖 wtd fleet · `doc-writer` agent · item `bamr87/bamr87:write_docs:f4680b0fa70d`
<!-- wtd-fleet:bamr87/bamr87:write_docs:f4680b0fa70d -->