### PR TITLE
docs: document the root dotfiles (.zshrc, .zprofile, .gitconfig) and their intended usage

### DIFF
--- a/docs/dotfiles.md
+++ b/docs/dotfiles.md
@@ -1,0 +1,140 @@
+---
+title: Root dotfiles (.zshrc, .zprofile, .gitconfig)
+description: What the home-directory dotfiles tracked at the repository root are for, and how to use them without clobbering your own shell configuration.
+---
+
+# Root dotfiles
+
+This repository tracks three files at its root that share their names with
+home-directory configuration files:
+
+| File | Normally lives at | Read by |
+| --- | --- | --- |
+| `.zshrc` | `~/.zshrc` | Zsh, for every interactive shell |
+| `.zprofile` | `~/.zprofile` | Zsh, once per login shell |
+| `.gitconfig` | `~/.gitconfig` | Git, as the per-user configuration |
+
+Because the repository root also holds site content (`_config.yml`, `index.md`,
+`pages/`), tooling config (`.editorconfig`, `.prettierrc`,
+`.pre-commit-config.yaml`), and a `Rakefile`, it is easy to misread these three
+files as something the project applies to your machine. This page exists to
+remove that ambiguity.
+
+## ⚠️ Do not copy or source them blindly
+
+`~/.zshrc`, `~/.zprofile`, and `~/.gitconfig` are *yours*. Copying the versions
+from this repository over them will silently destroy your aliases, your `PATH`
+adjustments, your prompt, and — in the case of `.gitconfig` — your commit
+identity, signing configuration, and credential helper settings.
+
+In particular, **do not** run anything of the shape:
+
+```sh
+# DON'T: overwrites your personal configuration with no backup
+cp .zshrc ~/.zshrc
+ln -sf "$PWD/.gitconfig" ~/.gitconfig
+```
+
+unless you have already backed up the originals and read the incoming files in
+full.
+
+## Intended usage
+
+> **Status: to be confirmed by the maintainer.**
+>
+> At the time of writing, no bootstrap script, `rake` task, or setup command in
+> this repository is *documented* as installing these files into `$HOME`. Until
+> that is confirmed one way or the other, treat them as **version-controlled
+> reference copies**: read them, borrow from them, but install nothing
+> automatically.
+>
+> If you are the maintainer, please replace this block with the definitive
+> answer — and, if an install step exists, the exact command to run. See the
+> checklist at the bottom of this page.
+
+### Reading them safely
+
+Inspect the files before doing anything with them:
+
+```sh
+cat .zshrc
+cat .zprofile
+cat .gitconfig
+```
+
+### Comparing against your own configuration
+
+A diff is the safest way to see what adopting a file would change:
+
+```sh
+diff -u ~/.zshrc    .zshrc    || true
+diff -u ~/.zprofile .zprofile || true
+diff -u ~/.gitconfig .gitconfig || true
+```
+
+(`|| true` keeps the command from reporting a non-zero exit status just because
+the files differ.)
+
+### Adopting parts of them
+
+If you decide you want something from these files, prefer copying the specific
+lines you want into your existing configuration over replacing the whole file.
+If you really do want to adopt a file wholesale, back up first:
+
+```sh
+cp ~/.zshrc ~/.zshrc.backup."$(date +%Y%m%d%H%M%S)"
+```
+
+For Git specifically, you can pull in this repository's settings *without*
+replacing your own file by using an include directive in `~/.gitconfig`, which
+lets your own values continue to take precedence if you place it near the top:
+
+```ini
+[include]
+    path = /absolute/path/to/this/repo/.gitconfig
+```
+
+Remove the include line to undo it. Verify what Git actually ended up with:
+
+```sh
+git config --list --show-origin
+```
+
+## Related files
+
+These are separate concerns and are *not* home-directory dotfiles, even though
+they sit in the same directory listing:
+
+- `.editorconfig`, `.prettierrc`, `.prettierignore`, `.markdownlintignore` —
+  per-repository editor and formatter settings, applied automatically by the
+  relevant tools when you work in this checkout.
+- `.pre-commit-config.yaml`, `.husky/` — commit-time hook configuration.
+- `.devcontainer/`, `docker-compose.yml` — containerised development
+  environment definitions.
+- `.env.example` — a template for local environment variables; copy it to your
+  own `.env` rather than editing the example in place.
+
+## Maintainer checklist
+
+To finish this page, confirm the following and edit the **Intended usage**
+section accordingly:
+
+- [ ] Does any script under `tools/`, any task in the `Rakefile`, or any
+      workflow in `.github/` install these files into `$HOME`? If so, document
+      the exact command here.
+- [ ] Does `.devcontainer/` copy, mount, or source them when the container is
+      built? If so, say so — that makes them active configuration inside the
+      container, not reference material.
+- [ ] Is `.gitconfig` intended as *repository-local* Git configuration (for
+      example via `core.hooksPath` or an `include.path` entry) rather than a
+      `$HOME` file? If so, reframe the table above.
+- [ ] Does `.gitconfig` contain personal identity, signing, or credential
+      values that should not be adopted by anyone else? If so, call that out
+      explicitly.
+- [ ] Once answered, delete this checklist and the "Status" caveat.
+
+A quick starting point:
+
+```sh
+git grep -n -e zshrc -e zprofile -e gitconfig -- Rakefile tools .devcontainer .github docker-compose.yml
+```

--- a/docs/dotfiles.md
+++ b/docs/dotfiles.md
@@ -5,8 +5,7 @@ description: What the home-directory dotfiles tracked at the repository root are
 
 # Root dotfiles
 
-This repository tracks three files at its root that share their names with
-home-directory configuration files:
+This repository tracks three files at its root that share their names with home-directory configuration files:
 
 | File | Normally lives at | Read by |
 | --- | --- | --- |
@@ -14,18 +13,11 @@ home-directory configuration files:
 | `.zprofile` | `~/.zprofile` | Zsh, once per login shell |
 | `.gitconfig` | `~/.gitconfig` | Git, as the per-user configuration |
 
-Because the repository root also holds site content (`_config.yml`, `index.md`,
-`pages/`), tooling config (`.editorconfig`, `.prettierrc`,
-`.pre-commit-config.yaml`), and a `Rakefile`, it is easy to misread these three
-files as something the project applies to your machine. This page exists to
-remove that ambiguity.
+Because the repository root also holds site content (`_config.yml`, `index.md`, `pages/`), tooling config (`.editorconfig`, `.prettierrc`, `.pre-commit-config.yaml`), and a `Rakefile`, it is easy to misread these three files as something the project applies to your machine. This page exists to remove that ambiguity.
 
 ## ⚠️ Do not copy or source them blindly
 
-`~/.zshrc`, `~/.zprofile`, and `~/.gitconfig` are *yours*. Copying the versions
-from this repository over them will silently destroy your aliases, your `PATH`
-adjustments, your prompt, and — in the case of `.gitconfig` — your commit
-identity, signing configuration, and credential helper settings.
+`~/.zshrc`, `~/.zprofile`, and `~/.gitconfig` are *yours*. Copying the versions from this repository over them will silently destroy your aliases, your `PATH` adjustments, your prompt, and — in the case of `.gitconfig` — your commit identity, signing configuration, and credential helper settings.
 
 In particular, **do not** run anything of the shape:
 
@@ -35,8 +27,7 @@ cp .zshrc ~/.zshrc
 ln -sf "$PWD/.gitconfig" ~/.gitconfig
 ```
 
-unless you have already backed up the originals and read the incoming files in
-full.
+unless you have already backed up the originals and read the incoming files in full.
 
 ## Intended usage
 
@@ -77,17 +68,13 @@ the files differ.)
 
 ### Adopting parts of them
 
-If you decide you want something from these files, prefer copying the specific
-lines you want into your existing configuration over replacing the whole file.
-If you really do want to adopt a file wholesale, back up first:
+If you decide you want something from these files, prefer copying the specific lines you want into your existing configuration over replacing the whole file. If you really do want to adopt a file wholesale, back up first:
 
 ```sh
 cp ~/.zshrc ~/.zshrc.backup."$(date +%Y%m%d%H%M%S)"
 ```
 
-For Git specifically, you can pull in this repository's settings *without*
-replacing your own file by using an include directive in `~/.gitconfig`, which
-lets your own values continue to take precedence if you place it near the top:
+For Git specifically, you can pull in this repository's settings *without* replacing your own file by using an include directive in `~/.gitconfig`, which lets your own values continue to take precedence if you place it near the top:
 
 ```ini
 [include]
@@ -102,12 +89,10 @@ git config --list --show-origin
 
 ## Related files
 
-These are separate concerns and are *not* home-directory dotfiles, even though
-they sit in the same directory listing:
+These are separate concerns and are *not* home-directory dotfiles, even though they sit in the same directory listing:
 
 - `.editorconfig`, `.prettierrc`, `.prettierignore`, `.markdownlintignore` —
-  per-repository editor and formatter settings, applied automatically by the
-  relevant tools when you work in this checkout.
+per-repository editor and formatter settings, applied automatically by the relevant tools when you work in this checkout.
 - `.pre-commit-config.yaml`, `.husky/` — commit-time hook configuration.
 - `.devcontainer/`, `docker-compose.yml` — containerised development
   environment definitions.
@@ -116,8 +101,7 @@ they sit in the same directory listing:
 
 ## Maintainer checklist
 
-To finish this page, confirm the following and edit the **Intended usage**
-section accordingly:
+To finish this page, confirm the following and edit the **Intended usage** section accordingly:
 
 - [ ] Does any script under `tools/`, any task in the `Rakefile`, or any
       workflow in `.github/` install these files into `$HOME`? If so, document


### PR DESCRIPTION
## What this does

Adds `docs/dotfiles.md`, a short reference explaining the three home-directory dotfiles tracked at the repository root:

- `.zshrc`
- `.zprofile`
- `.gitconfig`

The page states what is observable today, warns that blindly sourcing or copying them will overwrite a developer's own shell and Git configuration, and describes a non-destructive way to inspect them first.

## Why

The repository root mixes site content, tooling config, and home-directory dotfiles. Without a note, a newcomer can reasonably assume `.zshrc`/`.zprofile`/`.gitconfig` are meant to be symlinked or copied into `$HOME` — and clobber their own configuration. A short, explicit statement removes the ambiguity.

## Evidence this is based on

Only the repository's top-level listing and the root `README.md` were available to me. From that listing:

- `.zshrc`, `.zprofile`, `.gitconfig` exist at the repository root.
- `.devcontainer/`, `tools/`, and `Rakefile` exist and are plausible homes for a bootstrap step.
- `AGENTS.md`, `CLAUDE.md`, `CONTRIBUTING.md`, `SUBMODULES.md`, `CATALOG.md`, `SCHEMA.md`, and a `docs/` directory exist, so `docs/` is an established place for reference material.

## ⚠️ What I could NOT verify — please check before merging

I did not have the contents of `Rakefile`, `tools/`, `.devcontainer/`, `docker-compose.yml`, or `CONTRIBUTING.md`, so **I did not assert that any install mechanism does or does not exist.** The draft deliberately says "no installer is documented" rather than "no installer exists", and ends with a maintainer checklist. Please confirm and edit the file directly:

1. **Is there a bootstrap/install step?** Search for references to these files, e.g. `git grep -n -e zshrc -e zprofile -e gitconfig -- Rakefile tools .devcontainer .github docker-compose.yml`. If a rake task or script installs them, replace the "Intended usage" section with the exact command.
2. **Does the devcontainer consume them?** If `.devcontainer/devcontainer.json` or its Dockerfile copies/mounts these files, say so — that changes the answer from "reference only" to "used automatically inside the container".
3. **Is `.gitconfig` actually the *repo-local* config for this checkout** (e.g. referenced via `core.hooksPath`, `.husky/`, or `include.path`) rather than a `$HOME` file? If so, correct the framing.
4. **Does `.gitconfig` contain personal identity values** (`user.email`, signing keys, credential helpers)? If yes, the warning in the doc should be strengthened, and it may be worth a follow-up to scrub or template them.
5. **Delete the "Status" caveat block** once you have confirmed the answer — it is written for this PR's review and should not survive as permanent documentation.

No existing files are modified; this PR touches documentation only.

---
🤖 wtd fleet · `doc-writer` agent · item `bamr87/bamr87:write_docs:d75277925d56`
<!-- wtd-fleet:bamr87/bamr87:write_docs:d75277925d56 -->