### PR TITLE
docs: add REPOSITORY_MAP.md — newcomer orientation and pointers to existing docs

### DIFF
--- a/REPOSITORY_MAP.md
+++ b/REPOSITORY_MAP.md
@@ -1,8 +1,6 @@
 # Repository Map
 
-A newcomer's orientation to this repository. Every path below is present at the
-top level of the repo; the descriptions are short and, where noted, still need a
-maintainer's confirmation.
+A newcomer's orientation to this repository. Every path below is present at the top level of the repo; the descriptions are short and, where noted, still need a maintainer's confirmation.
 
 > **Status:** this file intentionally contains **no build, run, or test
 > commands** yet. See [Still to be documented](#still-to-be-documented) for what
@@ -10,19 +8,13 @@ maintainer's confirmation.
 
 ## What this repository is
 
-`bamr87/bamr87` is a GitHub profile repository that has grown into a monorepo.
-`README.md` renders as the profile page for the `bamr87` GitHub account and
-describes the author, Amr Abdel-Motaleb, a Solutions Architect and ERP
-specialist. GitHub reports the primary language as HTML and the default branch
-as `main`.
+`bamr87/bamr87` is a GitHub profile repository that has grown into a monorepo. `README.md` renders as the profile page for the `bamr87` GitHub account and describes the author, Amr Abdel-Motaleb, a Solutions Architect and ERP specialist. GitHub reports the primary language as HTML and the default branch as `main`.
 
-Alongside the profile content, the repository carries site sources, project
-submodules, tooling, and agent configuration — see the map below.
+Alongside the profile content, the repository carries site sources, project submodules, tooling, and agent configuration — see the map below.
 
 ## Existing documentation
 
-Start here. These files already exist and are the authoritative sources for
-their topics:
+Start here. These files already exist and are the authoritative sources for their topics:
 
 | Document | What it covers |
 | --- | --- |
@@ -36,8 +28,7 @@ their topics:
 
 ## Top-level layout
 
-Descriptions marked *(inferred)* are based on the filename and common
-convention rather than on reading the file; correct them if they are wrong.
+Descriptions marked *(inferred)* are based on the filename and common convention rather than on reading the file; correct them if they are wrong.
 
 ### Site and content
 
@@ -99,14 +90,12 @@ convention rather than on reading the file; correct them if they are wrong.
 
 ## Still to be documented
 
-The following are **not yet documented anywhere in this file**, because the
-exact commands must be read from the files that define them rather than guessed:
+The following are **not yet documented anywhere in this file**, because the exact commands must be read from the files that define them rather than guessed:
 
 - **Local setup and serving the site.** Read `Gemfile` and `_config.yml` /
   `_config_dev.yml` for the toolchain and its version constraints.
 - **Build / serve / test task names.** Read `Rakefile` and record the task names
-  it literally defines. Also check `.github/` workflows, which show how CI
-  invokes the project — a reliable cross-check that a command actually works.
+it literally defines. Also check `.github/` workflows, which show how CI invokes the project — a reliable cross-check that a command actually works.
 - **The container workflow.** Read `docker-compose.yml` for the real service
   name(s) before writing any `docker compose` invocation.
 - **The dev container path.** Read `.devcontainer/` for the Codespaces / VS Code
@@ -117,5 +106,4 @@ exact commands must be read from the files that define them rather than guessed:
 - **Submodule initialisation.** [`SUBMODULES.md`](SUBMODULES.md) likely already
   covers this; link to it rather than duplicating it.
 
-When those are confirmed, replace this section with the verified commands and
-add a short pointer from `README.md` to this file.
+When those are confirmed, replace this section with the verified commands and add a short pointer from `README.md` to this file.

--- a/REPOSITORY_MAP.md
+++ b/REPOSITORY_MAP.md
@@ -1,0 +1,121 @@
+# Repository Map
+
+A newcomer's orientation to this repository. Every path below is present at the
+top level of the repo; the descriptions are short and, where noted, still need a
+maintainer's confirmation.
+
+> **Status:** this file intentionally contains **no build, run, or test
+> commands** yet. See [Still to be documented](#still-to-be-documented) for what
+> is missing and where the answers live.
+
+## What this repository is
+
+`bamr87/bamr87` is a GitHub profile repository that has grown into a monorepo.
+`README.md` renders as the profile page for the `bamr87` GitHub account and
+describes the author, Amr Abdel-Motaleb, a Solutions Architect and ERP
+specialist. GitHub reports the primary language as HTML and the default branch
+as `main`.
+
+Alongside the profile content, the repository carries site sources, project
+submodules, tooling, and agent configuration — see the map below.
+
+## Existing documentation
+
+Start here. These files already exist and are the authoritative sources for
+their topics:
+
+| Document | What it covers |
+| --- | --- |
+| [`CONTRIBUTING.md`](CONTRIBUTING.md) | How to contribute. **Read this first** — it is the most likely home of the real setup and workflow instructions. |
+| [`SUBMODULES.md`](SUBMODULES.md) | Git submodule layout and handling (the repo has a `.gitmodules` file). |
+| [`SCHEMA.md`](SCHEMA.md) | Data/content schema documentation. |
+| [`CATALOG.md`](CATALOG.md) | Catalog of the repository's contents. |
+| [`AGENTS.md`](AGENTS.md) | Instructions and conventions for automated agents working in this repo. |
+| [`CLAUDE.md`](CLAUDE.md) | Claude-specific project instructions. |
+| [`README.md`](README.md) | Profile / biography and project index. |
+
+## Top-level layout
+
+Descriptions marked *(inferred)* are based on the filename and common
+convention rather than on reading the file; correct them if they are wrong.
+
+### Site and content
+
+| Path | Notes |
+| --- | --- |
+| `_config.yml` | Site configuration *(inferred: Jekyll)*. |
+| `_config_dev.yml` | A second, development-oriented site configuration *(inferred)*. |
+| `Gemfile` | Ruby dependency manifest, used with Bundler *(inferred)*. |
+| `index.md` | Site entry page *(inferred)*. |
+| `pages/` | Additional site pages. |
+| `_data/` | Structured data consumed by the site *(inferred: Jekyll `_data`)*. |
+| `assets/` | Static assets (images, styles, scripts). |
+| `diagrams/` | Diagram sources and/or exports. |
+| `docs/` | Documentation directory. |
+| `templates/` | Reusable templates. |
+| `specs/` | Specifications. |
+| `projects/` | Project directories — note the repo has a `.gitmodules` file, so some of these may be submodules; see [`SUBMODULES.md`](SUBMODULES.md). |
+| `_reports/` | Generated reports. |
+
+### Build, tooling, and environment
+
+| Path | Notes |
+| --- | --- |
+| `Rakefile` | Rake task definitions — the likely source of this project's build/serve/test tasks. |
+| `docker-compose.yml` | Container-based workflow. |
+| `.devcontainer/` | VS Code / Codespaces dev container definition. |
+| `.env.example` | Template for local environment variables — copy and fill in before running anything that reads it. |
+| `tools/` | Helper scripts and utilities. |
+| `home.code-workspace` | VS Code multi-root workspace file. |
+| `.vscode/` | Editor settings and recommended extensions. |
+
+### Quality gates
+
+| Path | Notes |
+| --- | --- |
+| `.pre-commit-config.yaml` | pre-commit hook configuration *(inferred)*. |
+| `.husky/` | Git hooks managed by Husky *(inferred)*. |
+| `.prettierrc`, `.prettierignore` | Prettier formatting configuration. |
+| `.markdownlintignore` | Paths excluded from Markdown linting. |
+| `.editorconfig` | Cross-editor formatting conventions. |
+| `.github/` | GitHub configuration: workflows, issue templates, and similar. |
+
+### Automation and agents
+
+| Path | Notes |
+| --- | --- |
+| `fleet.manifest.yml` | Manifest for automated agent work. |
+| `.mcp.json` | Model Context Protocol server configuration *(inferred)*. |
+| `.claude/` | Claude configuration directory. |
+
+### Shell and Git configuration
+
+| Path | Notes |
+| --- | --- |
+| `.zshrc`, `.zprofile` | Zsh shell configuration tracked in the repo (this repo doubles as a dotfiles home). |
+| `.gitconfig` | Git configuration tracked in the repo. |
+| `.gitmodules` | Submodule definitions — see [`SUBMODULES.md`](SUBMODULES.md). |
+| `.gitignore` | Ignored paths. |
+
+## Still to be documented
+
+The following are **not yet documented anywhere in this file**, because the
+exact commands must be read from the files that define them rather than guessed:
+
+- **Local setup and serving the site.** Read `Gemfile` and `_config.yml` /
+  `_config_dev.yml` for the toolchain and its version constraints.
+- **Build / serve / test task names.** Read `Rakefile` and record the task names
+  it literally defines. Also check `.github/` workflows, which show how CI
+  invokes the project — a reliable cross-check that a command actually works.
+- **The container workflow.** Read `docker-compose.yml` for the real service
+  name(s) before writing any `docker compose` invocation.
+- **The dev container path.** Read `.devcontainer/` for the Codespaces / VS Code
+  "Reopen in Container" flow.
+- **Required environment variables.** Read `.env.example` and describe each key.
+- **Hook installation.** Read `.pre-commit-config.yaml` and `.husky/` for how
+  contributors are expected to install hooks.
+- **Submodule initialisation.** [`SUBMODULES.md`](SUBMODULES.md) likely already
+  covers this; link to it rather than duplicating it.
+
+When those are confirmed, replace this section with the verified commands and
+add a short pointer from `README.md` to this file.


### PR DESCRIPTION
## What this does

Adds a single new documentation file, `REPOSITORY_MAP.md`, that gives a newcomer an orientation to the repository: what each top-level file and directory is, and where the existing docs live (`AGENTS.md`, `CATALOG.md`, `CONTRIBUTING.md`, `SCHEMA.md`, `SUBMODULES.md`).

No code, config, or existing documentation is modified.

## Why not edit README.md directly?

The original task asked for a build/run/test section in `README.md`. I did **not** do that, for two reasons:

1. **The commands are still unverified.** The evidence available to me was the top-level file listing plus a *truncated* copy of `README.md`. I have not seen the contents of `Rakefile`, `Gemfile`, `docker-compose.yml`, `.devcontainer/`, `.pre-commit-config.yaml`, or `CONTRIBUTING.md`. Writing `bundle exec jekyll serve` or `rake build` would be guessing at task and service names, which is exactly the failure mode this task was created to avoid.
2. **Rewriting README.md would be destructive.** My copy of `README.md` is truncated mid-document, so proposing a full replacement file would silently delete the tail of it.

A collision-free new file at the repository root was the safest way to deliver something useful without either inventing commands or losing content.

## What is verified vs. not

**Verified** (directly from the repository file listing):
- Every path named in `REPOSITORY_MAP.md` exists at the top level of the repository.
- The linked docs (`AGENTS.md`, `CATALOG.md`, `CLAUDE.md`, `CONTRIBUTING.md`, `SCHEMA.md`, `SUBMODULES.md`) exist.
- `README.md` front matter states the author and role; GitHub reports the primary language as HTML and the default branch as `main`.

**Not verified — please check before merging:**
- The one-line purpose I give for each file is inferred from the filename and from ecosystem convention (e.g. `Gemfile` → Bundler manifest, `_config.yml` → Jekyll site config), *not* from reading the files. Correct any that are wrong.
- I deliberately included **no** runnable commands. The "Still to be documented" section lists the exact files a maintainer needs to read to fill them in.
- I did **not** add YAML front matter to the new file. If `_config.yml` renders root-level Markdown as site pages and expects front matter (as `README.md` has), please add matching front matter or move the file under `docs/`.
- I did not check `docs/` for an existing file that already covers this ground; if one exists, close this PR and fold the useful bits into it instead.

## Suggested follow-up

Once a maintainer (or a follow-up run with file contents) confirms the real task names, the "Still to be documented" section here should be replaced with the actual commands, and a short "Getting started" pointer added near the top of `README.md` linking to this file.

---
🤖 wtd fleet · `doc-writer` agent · item `bamr87/bamr87:write_docs:e7ee4628baf2`
<!-- wtd-fleet:bamr87/bamr87:write_docs:e7ee4628baf2 -->