### PR TITLE
fix(actions-analytics): probe zero-job runs below the 6h clamp, not only above

### DIFF
--- a/.github/scripts/dash-gen/actions_analytics.py
+++ b/.github/scripts/dash-gen/actions_analytics.py
@@ -22,6 +22,11 @@ still count toward `success_rate_pct` and the failing flag; only their minutes a
 zeroed. Without this, one run parked for 68h at `billable: {}` contributed 4079.9
 phantom minutes and took over the fleet's fix queue (bamr87/bamr87#229).
 
+A parked run bills nothing at ANY duration, so the zero-jobs question is asked of
+every run past SUSPECT_RUN_MIN rather than only of runs past the 6h clamp — the
+narrower reading let a 5.5h zero-job run keep all 328.8 of its phantom minutes
+and put a healthy workflow on the fix queue a day after #229 was closed.
+
 The fleet `totals` are computed over bamr87-owned workflows only — the same
 population as the by_type / by_repo / by_day rollups. Mixing the two populations
 across a ratio's halves is how this file once published more waste than
@@ -76,6 +81,19 @@ WASTE_CONCLUSIONS = {"failure", "cancelled", "timed_out", "startup_failure"}
 # a backstop, not the primary filter: it bounds the blast radius of the next
 # stuck-run variant `cost_min` does not anticipate (bamr87/bamr87#229).
 MAX_RUN_MIN = 360.0
+
+# Wall clock above which a run is worth ASKING whether it dispatched any job.
+# Deliberately far below MAX_RUN_MIN: a parked run bills nothing no matter how
+# long it parks, so tying the zero-jobs probe to the 6h clamp only ever caught
+# the parked runs that happened to park for longer than a legal job (#229's
+# 68-hour run). bamr87/law-ai run 34062551261 parked for 5.5h — under the clamp,
+# `billable: {}`, zero jobs — and its 328.8 phantom minutes were 84% of its
+# workflow's reported spend, which is what put an otherwise healthy workflow on
+# the fix queue. Real runs here are bounded by SLOW_AVG_MIN (12m) and the
+# slowest fleet workflow's p95 (~28m), so a run past this threshold is already
+# an outlier and the probe stays proportional to outliers, not to the
+# population — the property that keeps this module's request count sane.
+SUSPECT_RUN_MIN = 60.0
 
 # Conclusions that say nothing about whether the workflow works. A run whose
 # `if:` gate declined is the system behaving correctly at ~zero cost, so it must
@@ -191,15 +209,25 @@ def cost_min(run, dur: float) -> float:
     * a run that never executed costs **0**, not its wall clock;
     * everything else is clamped to MAX_RUN_MIN, bounding the next variant.
 
+    The zero-jobs probe keys off SUSPECT_RUN_MIN, *not* off the MAX_RUN_MIN
+    clamp. Those are different questions and conflating them is what let this
+    bug survive #229: "did this run bill anything?" is answered by the job list
+    at any duration, while "how much do we credit a run we believe really ran?"
+    is what the 6h ceiling bounds. Gating the first on the second meant a run
+    had to park for longer than a legal job before anyone asked whether it had
+    run at all, so every parked run under 6h kept its full wall clock.
+
     Only the MINUTES are zeroed. The run still counts toward `success_rate_pct`
     and the `failing` flag — a startup failure genuinely is red, and suppressing
     it there would trade a cost bug for a correctness one.
     """
     if (run.conclusion or "") == "startup_failure":
         return 0.0
-    if dur <= MAX_RUN_MIN:
+    if dur <= SUSPECT_RUN_MIN:
         return dur
-    return 0.0 if has_no_jobs(run) else MAX_RUN_MIN
+    if has_no_jobs(run):
+        return 0.0
+    return min(dur, MAX_RUN_MIN)
 
 
 # --------------------------------------------------------------------------- #
@@ -526,7 +554,8 @@ def finalize(workflows, inactive, by_type, by_repo, by_day, days, scanned, now) 
         "inactive": sorted(inactive, key=lambda x: (x["repo"], x["workflow"])),
         "note": ("Cost = wall-clock run minutes (run_started_at → updated_at), a proxy for "
                  "billable minutes, with two bounds: a run that never executed "
-                 "(startup_failure, or zero jobs) counts as 0 minutes, and every other "
+                 "(startup_failure, or zero jobs — checked for every run over "
+                 f"{SUSPECT_RUN_MIN:.0f} min) counts as 0 minutes, and every other "
                  f"run is capped at {MAX_RUN_MIN:.0f} min — GitHub's own job ceiling — so a run "
                  "left parked in a non-terminal state cannot report minutes it never "
                  "billed. Those runs still count against the success rate; only their "

--- a/.github/scripts/dash-gen/test_actions_analytics.py
+++ b/.github/scripts/dash-gen/test_actions_analytics.py
@@ -148,6 +148,33 @@ def case_zero_job_failure_is_caught_by_the_job_probe() -> None:
     check("a short run is never probed for jobs", cost_of(short) == 30.0)
 
 
+def case_zero_job_run_under_the_clamp_costs_nothing() -> None:
+    """FAILS on the #229 code, which probed for jobs only ABOVE MAX_RUN_MIN.
+
+    Modelled on bamr87/law-ai run 34062551261: parked 5.48h (328.8 min) with
+    `total_count: 0` jobs and `billable: {}` — under the 6h clamp, so the old
+    `if dur <= MAX_RUN_MIN: return dur` handed back the full wall clock without
+    ever asking whether the run had executed. Those 328.8 phantom minutes were
+    84% of integration-tests.yml's reported 398.8 min and dragged its average to
+    15.95 min against a 3.45 min p95 — enough to flag a healthy workflow as
+    `high-cost-low-value, slow` and spend a slot on the fleet-doctor queue.
+    """
+    parked = FakeRun(conclusion="failure", hours=5.48, jobs=0)
+    check("a 5.5h zero-job run under the clamp costs 0 minutes",
+          cost_of(parked) == 0.0)
+
+    # The probe must stay bounded to outliers: anything at or under the suspect
+    # threshold is still billed on wall clock alone, without an API request.
+    just_under = FakeRun(conclusion="failure", hours=0.9, jobs=0, raises=True)
+    check("a run at 54 min is still never probed for jobs",
+          cost_of(just_under) == 54.0)
+
+    # A run that really did execute in that same band keeps its real cost —
+    # the fix must not zero genuine consumption between 1h and 6h.
+    real = FakeRun(conclusion="success", hours=2.5, jobs=2)
+    check("a 2.5h run that DID execute keeps its 150 min", cost_of(real) == 150.0)
+
+
 def case_duration_is_capped() -> None:
     """FAILS on the pre-fix code, which had no ceiling at all."""
     billable = FakeRun(conclusion="success", hours=PHANTOM_HOURS, jobs=3)
@@ -223,6 +250,7 @@ def case_note_documents_the_bounds() -> None:
     text = report["note"]
     check("the note states the zero-cost exclusion", "never executed" in text)
     check("the note states the cap", "360" in text)
+    check("the note states the zero-jobs probe threshold", "60 min" in text)
     check("the note states the owned-only totals", "owned" in text)
 
 
@@ -232,6 +260,7 @@ def case_note_documents_the_bounds() -> None:
 def main() -> int:
     for fn in (case_non_executing_runs_cost_nothing,
                case_zero_job_failure_is_caught_by_the_job_probe,
+               case_zero_job_run_under_the_clamp_costs_nothing,
                case_duration_is_capped,
                case_ordinary_runs_are_untouched,
                case_totals_range_over_one_population,


### PR DESCRIPTION
<!-- fleet-doctor key="bamr87/law-ai:.github/workflows/integration-tests.yml" -->

## Problem

**Repo:** bamr87/law-ai · **Workflow:** `.github/workflows/integration-tests.yml` · **Signals:** `high-cost-low-value`, `slow`

The queue reported 25 runs, 398.8 min total, 15.95 min avg, **3.45 min p95**, 334.9 min wasted, 16.0% effective — against an **88% success rate**.

That shape is self-contradictory. An average 4.6× the p95 means one run dominates the mean, and "16% effective at 88% success" means the waste is concentrated in almost no runs. So I went to the run list before touching the workflow:

```
34062551261  failure  pull_request  feat/backlog-zero  2026-09-06T21:56:42Z → 2026-09-07T03:25:29Z
```

5 hours 29 minutes, where every other run in the window finishes in about three. Its API record:

```
$ gh api repos/bamr87/law-ai/actions/runs/34062551261/jobs --jq .total_count
0
$ gh api repos/bamr87/law-ai/actions/runs/34062551261/timing --jq '{run_duration_ms,billable}'
{"billable":{},"run_duration_ms":19727000}
```

**Zero jobs. Empty `billable` map. GitHub charged nothing for it.** The run never reached a runner; it parked. The 328.8 minutes are elapsed time, not compute.

Netting the phantom out of the reported totals reconciles every number exactly:

| | reported | phantom | actual |
|---|---|---|---|
| total minutes | 398.8 | 328.8 | **70.0** across 24 real runs |
| average | 15.95 | | **2.9** — consistent with the 3.45 p95 |
| waste | 334.9 | 328.8 | **6.1** (the two real ~3 min failures) |
| effectiveness | 16.0% | | **~91%** |

There is nothing wrong with `integration-tests.yml`. It already carries `timeout-minutes: 15`, `concurrency` with `cancel-in-progress: true`, `paths:` filters on both triggers, and `cache: pip`. It is one of the better-configured workflows in the fleet. **The defect is in the hub's cost model**, and it spent one of this queue's four slots on a healthy workflow.

## Root cause

`.github/scripts/dash-gen/actions_analytics.py` — `cost_min`, as left by #229/#231:

```python
if (run.conclusion or "") == "startup_failure":
    return 0.0
if dur <= MAX_RUN_MIN:        # 360.0
    return dur
return 0.0 if has_no_jobs(run) else MAX_RUN_MIN
```

The zero-jobs probe is **gated behind the clamp**. It only fires for runs whose wall clock exceeds six hours, so a run had to park for *longer than a legally-runnable job* before anything asked whether it had run at all. Every zero-job run under 6h keeps its full wall clock.

At 328.8 min this run falls in that gap: under 360, so line 3 returns `dur` and `has_no_jobs()` is never called.

This is not stale data. #229 closed at 2026-09-06 19:49 UTC with commit `eb57873a` ("bound the cost proxy and total over one population", #231); the dataset behind this work order was generated 2026-09-07 06:40 UTC. **The phantom got through the fixed code.** #229 caught its own 68-hour instance and the whole band above 6h, and left everything below it untouched.

## Fix

Separate the two questions the old branch conflated:

- *"Did this run bill anything?"* — answered by the job list at **any** duration.
- *"How much do we credit a run we believe really ran?"* — what the 6h ceiling bounds.

Add `SUSPECT_RUN_MIN = 60.0` as the probe threshold and keep `MAX_RUN_MIN` as the outer clamp:

```python
if (run.conclusion or "") == "startup_failure":
    return 0.0
if dur <= SUSPECT_RUN_MIN:
    return dur
if has_no_jobs(run):
    return 0.0
return min(dur, MAX_RUN_MIN)
```

The probe stays **proportional to outliers, not to the population** — the property `has_no_jobs`'s docstring insists on, since each call costs an API request across ~40 repos. Real runs here are bounded by `SLOW_AVG_MIN` (12 min) and the slowest fleet workflow's p95 (~28 min), so crossing 60 min of wall clock already makes a run exceptional. Runs at or under the threshold are billed on wall clock alone, with no extra request — unchanged from today.

Also updates the module docstring and the `note:` published into `_data/actions_usage.yml`, which is the only place a reader of the data file learns the cost model.

### Tests

Adds `case_zero_job_run_under_the_clamp_costs_nothing`, modelled on run 34062551261 (5.48h, zero jobs), which **fails on the pre-fix code**. It pins both edges of the new threshold so the fix cannot over-reach: a 54-minute run is still never probed (the fake raises if asked), and a genuine 2.5h run *that did execute* keeps its full 150 minutes.

The five existing cases are unaffected — I traced each against the new branch structure; the 68h cases still zero or clamp identically, and `case_ordinary_runs_are_untouched`'s 2.0h run now takes the probe and returns its exact wall clock.

⚠️ **I could not execute the suite** — Python execution is blocked in this agent's sandbox, so the tests are verified by reading, not by running. CI runs them via `tools/run-all-tests.sh` ("the control plane's own `dash-gen` tests"); please confirm green before merge.

## Expected impact

- Removes ~329 phantom minutes from one workflow. More importantly it closes the whole 1h–6h band, where phantom runs are *more* likely than above 6h simply because parking briefly is commoner than parking for days.
- Stops the fleet-doctor queue burning slots on healthy workflows. `remediate` ranks on severity then wasted minutes, so a phantom outranks genuine cost — this queue had law-ai above three real failures.
- Restores `integration-tests.yml` to its true profile: ~2.9 min average, ~91% effective, no flags.

**No change is needed in bamr87/law-ai.** If the `remediate` dedupe is happy to see this marker on a hub PR, that is the intent — the candidate is law-ai's workflow, the defect is the hub's measurement of it.

## Links

- The phantom run: https://github.com/bamr87/law-ai/actions/runs/34062551261
- Prior incomplete fix: https://github.com/bamr87/bamr87/issues/229 → https://github.com/bamr87/bamr87/pull/231
- Dash Actions analytics: https://bamr87.github.io/bamr87/actions/

🤖 Generated with [Claude Code](https://claude.com/claude-code)