### PR TITLE
fix(ci): size issue-pipeline T2/T3 turn budgets to the documented 400

### DIFF
--- a/.github/workflows/issue-pipeline.yml
+++ b/.github/workflows/issue-pipeline.yml
@@ -600,9 +600,12 @@ jobs:
           # limit and the job failed with work still in flight. At the observed
           # ~8.7s/turn, 400 turns ≈ 58 min, which fits inside 90 with headroom for
           # checkout/setup/post steps and lets the job timeout be the real ceiling.
+          # Run 34328433164 repeated it verbatim — 201 turns, $22.82 billed, the
+          # whole job over in 24m of the 90 — because the value below still said
+          # 200 while this comment prescribed 400.
           claude_args: >-
             --model opus
-            --max-turns 200
+            --max-turns 400
             --allowedTools "Bash(gh:*),Bash(git:*),Bash(mkdir:*),Bash(cd:*),Bash(ls:*),Bash(cat:*),Bash(jq:*),Bash(npm:*),Bash(npx:*),Bash(node:*),Bash(python3:*),Bash(pip:*),Bash(pytest:*),Bash(bundle:*),Bash(ruby:*),Bash(go:*),Bash(cargo:*),Bash(make:*),Bash(shellcheck:*),Bash(docker:*),Bash(curl:*),Bash(tools/:*),Bash(./test/:*),Bash(test/:*),Bash(./scripts/:*),Bash(scripts/:*),Read,Grep,Glob,Edit,Write"
           prompt: |
             You are **tier 2** of the bamr87 fleet's issue pipeline:
@@ -800,7 +803,7 @@ jobs:
           # 33301167779 with an hour of its 90-minute budget unused.
           claude_args: >-
             --model opus
-            --max-turns 200
+            --max-turns 400
             --allowedTools "Bash(gh:*),Bash(git:*),Bash(mkdir:*),Bash(cd:*),Bash(ls:*),Bash(cat:*),Bash(jq:*),Bash(npm:*),Bash(npx:*),Bash(node:*),Bash(python3:*),Bash(pip:*),Bash(pytest:*),Bash(bundle:*),Bash(ruby:*),Bash(go:*),Bash(cargo:*),Bash(make:*),Bash(shellcheck:*),Bash(docker:*),Bash(curl:*),Bash(tools/:*),Bash(./test/:*),Bash(test/:*),Bash(./scripts/:*),Bash(scripts/:*),Read,Grep,Glob,Edit,Write"
           prompt: |
             You are **tier 3** of the bamr87 fleet's issue pipeline: COMPLETION.


### PR DESCRIPTION
<!-- fleet-doctor key="bamr87/bamr87:.github/workflows/issue-pipeline.yml" -->

## Problem

`bamr87/bamr87` · `.github/workflows/issue-pipeline.yml` · signal `failing`.

Run [34328433164](https://github.com/bamr87/bamr87/actions/runs/34328433164) (scheduled, 2026-09-09 08:18 UTC): `scan`, `tier1` and `tier3` all went green; **`Tier 2 · implement & open draft PR` failed** after 24m24s. The failing step is `Implement` (the `anthropics/claude-code-action@v1` call) — every other step in the job succeeded.

## Root cause

Not auth, not a missing dependency — the agent ran out of *turns*, not time:

```
##[error]Execution failed: Reached maximum number of turns (200)
##[error]Action failed with error: Claude execution failed: Reached maximum number of turns (200)
##[error]Process completed with exit code 1.
```

The job's own `Diagnose Claude failure` step reached the same conclusion and ruled auth out explicitly:

```
##[warning]Tier 2 — implement: Claude ran (201 turn(s), $22.81825849999999 billed)
and still failed — an agent/tooling failure, not auth.
```

The action burned 1,352,500 ms (~22.5 min) of a job that allows `timeout-minutes: 90`. The **turn** ceiling bound the run at roughly a quarter of the **time** ceiling, so the job died with work still in flight and $22.82 already spent — the worst of both ends: paid for, nothing shipped.

What makes this a one-line defect rather than a judgement call is that the fix was already written down. The comment sitting directly above `claude_args` in both the T2 and T3 jobs analyses this exact failure mode, cites the earlier occurrence (run 33301167779), and prescribes the number:

```yaml
# Turn budget must be sized against `timeout-minutes: 90`, not guessed:
# ... Run 33301167779 hit the ceiling at 201 turns having used only
# 29 of its 90 minutes, i.e. the TURN limit bound at a third of the time
# limit and the job failed with work still in flight. At the observed
# ~8.7s/turn, 400 turns ≈ 58 min, which fits inside 90 with headroom for
# checkout/setup/post steps and lets the job timeout be the real ceiling.
claude_args: >-
  --model opus
  --max-turns 200     # <- the comment says 400
```

The comment and the code disagreed, so the previously-diagnosed failure recurred verbatim: same 201 turns, same ceiling, same exit 1.

## Fix

Bring both values in line with the sizing already documented above them:

- `tier2` → `--max-turns 200` → `400`
- `tier3` → `--max-turns 200` → `400`

T3 is included because it is the same workflow file, it carries the same `--max-turns 200` under a comment that says *"Same sizing as T2"* and records that **it hit the same 201-turn ceiling in the same earlier run** — its loop (`read checks → read failing log → fix → push → re-check` over up to 4 PRs) spends turns on CI round trips it cannot control. It happened to survive this run at 10m50s; leaving it at 200 leaves the identical trap armed for the next busy queue.

Turn budget re-checked against *this* run's evidence rather than the old estimate: 201 turns in 22.5 min is ~6.7 s/turn, so 400 turns ≈ 45 min — comfortably inside `timeout-minutes: 90`, with room for checkout, `setup/dash-gen`, the queue refresh and the post steps. The job timeout becomes the real ceiling, which is what the comment asked for.

No `continue-on-error`, no retry, no cap reduction: the per-run workload (`issue_pipeline.tiers.implement.max_issues: 3`) is unchanged and the agent is simply allowed to finish it.

## Expected impact

Tier 2 stops failing on queues of 3 issues, and the ~$23/run currently spent reaching an error instead of a draft PR converts into actual PRs. A run that genuinely wedges is still bounded — by `timeout-minutes: 90`, as designed.

## Also observed (not fixed here — out of this candidate's scope)

The `Refresh the tier-2 queue` step succeeded but dropped five repos on the floor:

```
! bamr87/zer0-CMS: IndexError: list index out of range
! bamr87/gitnexus: IndexError: list index out of range
! bamr87/irony-works: IndexError: list index out of range
! bamr87/.github: IndexError: list index out of range
! bamr87/SCHEMA: IndexError: list index out of range
~ 5 repo(s) skipped (error)
```

`dash-gen issues` swallows the exception per repo and exits 0, so those five repos have been silently excluded from every tier queue without ever turning the workflow red. Unrelated to this failure and deliberately left alone here.

## Links

- Failing run: https://github.com/bamr87/bamr87/actions/runs/34328433164
- Prior identical failure cited in the code comment: https://github.com/bamr87/bamr87/actions/runs/33301167779
- Actions analytics: https://bamr87.github.io/bamr87/actions/

🤖 Generated with [Claude Code](https://claude.com/claude-code)
